### PR TITLE
Update shader-srcs.js

### DIFF
--- a/src/shader-srcs.js
+++ b/src/shader-srcs.js
@@ -74,7 +74,7 @@ void main() {
 	float stepSizeFast = sliceSize * 1.9;
 	vec4 deltaDirFast = vec4(dir.xyz * stepSizeFast, stepSizeFast);
 	while (samplePos.a <= len) {
-		float val = texture(volume, samplePos.xyz).r;
+		float val = texture(volume, samplePos.xyz).a;
 		if (val > 0.01) break;
 		samplePos += deltaDirFast; //advance ray position
 	}


### PR DESCRIPTION
Changed r to a when doing fast pass.  This solves the issue of colors with no red not being rendered for volumes.  The using a instead of r is already being done during the fast pass for the overlay.