### PR TITLE
RGB fixes and INT64 support

### DIFF
--- a/src/niivue.js
+++ b/src/niivue.js
@@ -106,8 +106,8 @@ export const Niivue = function (options = {}) {
   this.sliceTypeRender = 4;
   this.sliceType = this.sliceTypeMultiplanar; // sets current view in webgl canvas
   this.scene = {};
-  this.scene.renderAzimuth = -90; //-45;
-  this.scene.renderElevation = 90; //-165; //15;
+  this.scene.renderAzimuth = 110; //-45;
+  this.scene.renderElevation = 15; //-165; //15;
   this.scene.crosshairPos = [0.5, 0.5, 0.5];
   this.scene.clipPlane = [0, 0, 0, 0];
   this.scene.mousedown = false;

--- a/src/niivue.js
+++ b/src/niivue.js
@@ -2558,22 +2558,7 @@ Niivue.prototype.calculateMvpMatrix = function (object3D) {
   }
   let whratio = this.gl.canvas.clientWidth / this.gl.canvas.clientHeight;
   let projectionMatrix = mat.mat4.create();
-  //position of vertex furthest from origin: this should be computed ONCE in nvimage.js
-  let dx = Math.max(
-    Math.abs(object3D.extentsMax[0]),
-    Math.abs(object3D.extentsMin[0])
-  );
-  let dy = Math.max(
-    Math.abs(object3D.extentsMax[1]),
-    Math.abs(object3D.extentsMin[1])
-  );
-  let dz = Math.max(
-    Math.abs(object3D.extentsMax[2]),
-    Math.abs(object3D.extentsMin[2])
-  );
-  let furthestVertexFromOrigin = Math.sqrt(dx * dx + dy * dy + dz * dz);
-  //default volScaleMultiplier ~1.0: see entire object even if ~45-degree azimuth/elevation
-  let scale = (0.7 * furthestVertexFromOrigin * 1.0) / this.volScaleMultiplier; //2.0 WebGL viewport has range of 2.0 [-1,-1]...[1,1]
+  let scale = (0.7 * object3D.furthestVertexFromOrigin * 1.0) / this.volScaleMultiplier; //2.0 WebGL viewport has range of 2.0 [-1,-1]...[1,1]
   if (whratio < 1)
     //tall window: "portrait" mode, width constrains
     mat.mat4.ortho(

--- a/src/niivue.js
+++ b/src/niivue.js
@@ -1753,7 +1753,7 @@ Niivue.prototype.refreshLayers = function (overlayItem, layer, numLayers) {
     // raw input data
     this.gl.texStorage3D(
       this.gl.TEXTURE_3D,
-      6,
+      1,
       this.gl.R8UI,
       hdr.dims[1],
       hdr.dims[2],
@@ -1775,7 +1775,7 @@ Niivue.prototype.refreshLayers = function (overlayItem, layer, numLayers) {
   } else if (hdr.datatypeCode === 4) {
     this.gl.texStorage3D(
       this.gl.TEXTURE_3D,
-      6,
+      1,
       this.gl.R16I,
       hdr.dims[1],
       hdr.dims[2],
@@ -1798,7 +1798,7 @@ Niivue.prototype.refreshLayers = function (overlayItem, layer, numLayers) {
   } else if (hdr.datatypeCode === 16) {
     this.gl.texStorage3D(
       this.gl.TEXTURE_3D,
-      6,
+      1,
       this.gl.R32F,
       hdr.dims[1],
       hdr.dims[2],
@@ -1823,7 +1823,7 @@ Niivue.prototype.refreshLayers = function (overlayItem, layer, numLayers) {
     img32f = Float32Array.from(img);
     this.gl.texStorage3D(
       this.gl.TEXTURE_3D,
-      6,
+      1,
       this.gl.R32F,
       hdr.dims[1],
       hdr.dims[2],
@@ -1849,7 +1849,7 @@ Niivue.prototype.refreshLayers = function (overlayItem, layer, numLayers) {
     this.gl.uniform1i(orientShader.uniforms["hasAlpha"], false);
     this.gl.texStorage3D(
       this.gl.TEXTURE_3D,
-      6,
+      1,
       this.gl.RGB8UI,
       hdr.dims[1],
       hdr.dims[2],
@@ -1871,7 +1871,7 @@ Niivue.prototype.refreshLayers = function (overlayItem, layer, numLayers) {
   } else if (hdr.datatypeCode === 512) {
     this.gl.texStorage3D(
       this.gl.TEXTURE_3D,
-      6,
+      1,
       this.gl.R16UI,
       hdr.dims[1],
       hdr.dims[2],
@@ -1896,7 +1896,7 @@ Niivue.prototype.refreshLayers = function (overlayItem, layer, numLayers) {
     this.gl.uniform1i(orientShader.uniforms["hasAlpha"], true);
     this.gl.texStorage3D(
       this.gl.TEXTURE_3D,
-      6,
+      1,
       this.gl.RGBA8UI,
       hdr.dims[1],
       hdr.dims[2],

--- a/src/nvimage.js
+++ b/src/nvimage.js
@@ -694,14 +694,18 @@ NVImage.prototype.getValue = function (x, y, z) {
 function getExtents(positions) {
   const min = positions.slice(0, 3);
   const max = positions.slice(0, 3);
+  let mxDx = 0.0;
   for (let i = 3; i < positions.length; i += 3) {
     for (let j = 0; j < 3; ++j) {
       const v = positions[i + j];
       min[j] = Math.min(v, min[j]);
       max[j] = Math.max(v, max[j]);
     }
+    let dx = (positions[i]*positions[i])+(positions[i+1]*positions[i+1])+(positions[i+2]*positions[i+2]);
+    mxDx = Math.max(mxDx, dx);
   }
-  return { min, max };
+  let furthestVertexFromOrigin =  Math.sqrt(mxDx)
+  return { min, max, furthestVertexFromOrigin };
 }
 
 // returns the left, right, up, down, front and back via pixdims, qform or sform
@@ -962,5 +966,6 @@ NVImage.prototype.toNiivueObject3D = function (id, gl) {
   const extents = getExtents(positions);
   obj3D.extentsMin = extents.min;
   obj3D.extentsMax = extents.max;
+  obj3D.furthestVertexFromOrigin = extents.furthestVertexFromOrigin;
   return obj3D;
 };

--- a/src/nvimage.js
+++ b/src/nvimage.js
@@ -103,6 +103,30 @@ export var NVImage = function (
     case this.DT_RGBA32:
       this.img = new Uint8Array(imgRaw);
       break;
+    case this.DT_INT8:
+      let i8 = new Int8Array(imgRaw);
+      var vx8 = i8.length;
+      this.img = new Int16Array(vx8);
+      for (var i = 0; i < vx8 - 1; i++)
+         this.img[i] = i8[i];
+      this.hdr.datatypeCode = this.DT_SIGNED_SHORT;
+      break;
+    case this.DT_UINT32:
+      let u32 = new Uint32Array(imgRaw);
+      var vx32 = u32.length;
+      this.img = new Float64Array(vx32);
+      for (var i = 0; i < vx32 - 1; i++)
+         this.img[i] = u32[i];
+      this.hdr.datatypeCode = this.DT_DOUBLE;
+      break;
+    case this.DT_SIGNED_INT: 
+      let i32 = new Int32Array(imgRaw);
+      var vxi32 = i32.length;
+      this.img = new Float64Array(vxi32);
+      for (var i = 0; i < vxi32 - 1; i++)
+         this.img[i] = i32[i];
+      this.hdr.datatypeCode = this.DT_DOUBLE;
+      break;
     case this.DT_INT64:
       let i64 = new BigInt64Array(imgRaw);
       let vx = i64.length;

--- a/src/nvimage.js
+++ b/src/nvimage.js
@@ -103,6 +103,14 @@ export var NVImage = function (
     case this.DT_RGBA32:
       this.img = new Uint8Array(imgRaw);
       break;
+    case this.DT_INT64:
+      let i64 = new BigInt64Array(imgRaw);
+      let vx = i64.length;
+      this.img = new Float64Array(vx);
+      for (var i = 0; i < vx - 1; i++)
+         this.img[i] = Number(i64[i]);
+      this.hdr.datatypeCode = this.DT_DOUBLE;
+      break;
     default:
       throw "datatype " + this.hdr.datatypeCode + " not supported";
   }
@@ -659,6 +667,16 @@ String.prototype.getBytes = function () {
 
 NVImage.prototype.getValue = function (x, y, z) {
   const { nx, ny } = this.getImageMetadata();
+  if (this.hdr.datatypeCode === this.DT_RGBA32) {
+    let vx = 4 * (x + y * nx + z * nx * ny);
+    //convert rgb to luminance
+    return Math.round(this.img[vx] * 0.21 + this.img[vx+1] * 0.72 + this.img[vx+2] * 0.07);
+  }
+  if (this.hdr.datatypeCode === this.DT_RGB) {
+    let vx = 3 * (x + y * nx + z * nx * ny);
+    //convert rgb to luminance
+    return Math.round(this.img[vx] * 0.21 + this.img[vx+1] * 0.72 + this.img[vx+2] * 0.07);
+  }
   return this.img[x + y * nx + z * nx * ny];
 };
 

--- a/src/shader-srcs.js
+++ b/src/shader-srcs.js
@@ -368,12 +368,11 @@ uniform lowp sampler3D blend3D;
 uniform float opacity;
 uniform mat4 mtx;
 uniform bool hasAlpha;
-
 void main(void) {
  uvec4 aColor = texture(intensityVol, vec3(TexCoord.xy, coordZ));
- FragColor = vec4(float(aColor.r) / 255.0f, float(aColor.g) / 255.0f, float(aColor.b) / 255.0f, float(aColor.a) / 255.0f);
+ FragColor = vec4(float(aColor.r) / 255.0, float(aColor.g) / 255.0, float(aColor.b) / 255.0, float(aColor.a) / 255.0);
  if (!hasAlpha)
-   FragColor.a = (FragColor.r * 0.21f + FragColor.g * 0.72f + FragColor.b * 0.07);
+   FragColor.a = (FragColor.r * 0.21 + FragColor.g * 0.72 + FragColor.b * 0.07);
  FragColor.a *= opacity;
 }`;
 
@@ -422,7 +421,6 @@ in vec3 texCoords;
 uniform mat4 mvpMtx;
 out vec3 posColor;
 void main(void) {
-	// gl_Position =  mvpMtx * vec4(pos, 1.0); // mvpMtx * vec4(2.0 * (pos.xyz - 0.5), 1.0);
 	gl_Position = mvpMtx * vec4(pos, 1.0);
 	posColor = texCoords;
 }`;

--- a/src/shader-srcs.js
+++ b/src/shader-srcs.js
@@ -370,11 +370,10 @@ uniform mat4 mtx;
 uniform bool hasAlpha;
 
 void main(void) {
-vec4 vx = vec4(TexCoord.xy, coordZ, 1.0);// * mtx;
- 
- uvec4 aColor = texture(intensityVol, vx.xyz);
- float a = hasAlpha ? float(aColor.a) / 255.0f : float(aColor.r) * 0.21f + float(aColor.g) * 0.72f + float(aColor.b) * 0.07;  
- FragColor = vec4(float(aColor.r) / 255.0f, float(aColor.g) / 255.0f, float(aColor.b) / 255.0f, a);
+ uvec4 aColor = texture(intensityVol, vec3(TexCoord.xy, coordZ));
+ FragColor = vec4(float(aColor.r) / 255.0f, float(aColor.g) / 255.0f, float(aColor.b) / 255.0f, float(aColor.a) / 255.0f);
+ if (!hasAlpha)
+   FragColor.a = (FragColor.r * 0.21f + FragColor.g * 0.72f + FragColor.b * 0.07);
  FragColor.a *= opacity;
 }`;
 


### PR DESCRIPTION
 - getValue returns luminance for RGB/RGBA images, [closes issue 42](https://github.com/niivue/niivue/issues/42).
 - Support for int64 (overflows if value exceeds 2^53). Handles masks and segmentation maps created by [nibabel](https://github.com/nipy/nibabel/issues/1046) and [nilearn](https://github.com/nilearn/nilearn/issues/3167) users.