### PR TITLE
Experimental Atlas support

### DIFF
--- a/src/nvimage.js
+++ b/src/nvimage.js
@@ -154,7 +154,7 @@ export var NVImage = function (
     this.hdr.affine = affine;
   }
   affineOK = isAffineOK(this.hdr.affine);
-  if (affineOK) {
+  if (!affineOK) {
     console.log("Defective NIfTI: spatial transform does not make sense");
     let x = this.hdr.pixDims[1];
     let y = this.hdr.pixDims[2];
@@ -171,6 +171,7 @@ export var NVImage = function (
       [0, 0, z, 0],
       [0, 0, 0, 1],
     ];
+    this.hdr.affine = affine;
   } //defective affine
 
   let imgRaw = null;

--- a/src/shader-srcs.js
+++ b/src/shader-srcs.js
@@ -313,6 +313,57 @@ export var fragOrientShaderF = `#version 300 es
 uniform highp sampler3D intensityVol;
 `;
 
+//uniform vec2 canvasWidthHeight;
+export var fragOrientShaderAtlas= `#line 309
+precision highp int;
+precision highp float;
+in vec2 TexCoord;
+out vec4 FragColor;
+uniform float coordZ;
+uniform float layer;
+uniform float numLayers;
+uniform highp sampler2D colormap;
+uniform lowp sampler3D blend3D;
+uniform float opacity;
+uniform vec3 xyzFrac;
+uniform mat4 mtx;
+void main(void) {
+ vec4 vx = vec4(TexCoord.x, TexCoord.y, coordZ, 1.0) * mtx;
+ uint idx = texture(intensityVol, vx.xyz).r;
+ FragColor = vec4(0.0, 0.0, 0.0, 0.0);
+ if (idx == uint(0))
+   return;
+ if (xyzFrac.x > 0.0) { //outline
+   vx = vec4(TexCoord.x+xyzFrac.x, TexCoord.y, coordZ, 1.0) * mtx;
+   uint R = texture(intensityVol, vx.xyz).r;
+   vx = vec4(TexCoord.x-xyzFrac.x, TexCoord.y, coordZ, 1.0) * mtx;
+   uint L = texture(intensityVol, vx.xyz).r;
+   vx = vec4(TexCoord.x, TexCoord.y+xyzFrac.y, coordZ, 1.0) * mtx;
+   uint A = texture(intensityVol, vx.xyz).r;
+   vx = vec4(TexCoord.x, TexCoord.y-xyzFrac.y, coordZ, 1.0) * mtx;
+   uint P = texture(intensityVol, vx.xyz).r;
+   vx = vec4(TexCoord.x, TexCoord.y, coordZ+xyzFrac.z, 1.0) * mtx;
+   uint S = texture(intensityVol, vx.xyz).r;
+   vx = vec4(TexCoord.x, TexCoord.y, coordZ-xyzFrac.z, 1.0) * mtx;
+   uint I = texture(intensityVol, vx.xyz).r;
+   if ((idx == R) && (idx == L) && (idx == A) && (idx == P) && (idx == S) && (idx == I))
+     return;
+ }
+ idx = ((idx - uint(1)) % uint(100))+uint(1);
+ float fx = (float(idx)+0.5) / 256.0;
+ float y = (2.0 * layer + 1.0)/(2.0 * numLayers);
+ FragColor = texture(colormap, vec2(fx, y)).rgba;
+ FragColor.a *= opacity;
+ if (layer < 2.0) return;
+ vec2 texXY = TexCoord.xy*0.5 +vec2(0.5,0.5);
+ vec4 prevColor = texture(blend3D, vec3(texXY, coordZ));
+ // https://en.wikipedia.org/wiki/Alpha_compositing
+ float aout = FragColor.a + (1.0 - FragColor.a) * prevColor.a;
+ if (aout <= 0.0) return;
+ FragColor.rgb = ((FragColor.rgb * FragColor.a) + (prevColor.rgb * prevColor.a * (1.0 - FragColor.a))) / aout;
+ FragColor.a = aout;
+}`;
+
 export var fragOrientShader = `#line 309
 precision highp int;
 precision highp float;
@@ -369,7 +420,8 @@ uniform float opacity;
 uniform mat4 mtx;
 uniform bool hasAlpha;
 void main(void) {
- uvec4 aColor = texture(intensityVol, vec3(TexCoord.xy, coordZ));
+ vec4 vx = vec4(TexCoord.xy, coordZ, 1.0) * mtx;
+ uvec4 aColor = texture(intensityVol, vx.xyz);
  FragColor = vec4(float(aColor.r) / 255.0, float(aColor.g) / 255.0, float(aColor.b) / 255.0, float(aColor.a) / 255.0);
  if (!hasAlpha)
    FragColor.a = (FragColor.r * 0.21 + FragColor.g * 0.72 + FragColor.b * 0.07);

--- a/src/shader-srcs.js
+++ b/src/shader-srcs.js
@@ -420,7 +420,7 @@ uniform float opacity;
 uniform mat4 mtx;
 uniform bool hasAlpha;
 void main(void) {
- vec4 vx = vec4(TexCoord.xy, coordZ, 1.0);// * mtx;
+ vec4 vx = vec4(TexCoord.xy, coordZ, 1.0) * mtx;
  uvec4 aColor = texture(intensityVol, vx.xyz);
  FragColor = vec4(float(aColor.r) / 255.0, float(aColor.g) / 255.0, float(aColor.b) / 255.0, float(aColor.a) / 255.0);
  if (!hasAlpha)

--- a/src/shader-srcs.js
+++ b/src/shader-srcs.js
@@ -420,7 +420,7 @@ uniform float opacity;
 uniform mat4 mtx;
 uniform bool hasAlpha;
 void main(void) {
- vec4 vx = vec4(TexCoord.xy, coordZ, 1.0) * mtx;
+ vec4 vx = vec4(TexCoord.xy, coordZ, 1.0);// * mtx;
  uvec4 aColor = texture(intensityVol, vx.xyz);
  FragColor = vec4(float(aColor.r) / 255.0, float(aColor.g) / 255.0, float(aColor.b) / 255.0, float(aColor.a) / 255.0);
  if (!hasAlpha)


### PR DESCRIPTION
 - Automatically detects Atlases where the [NIfTI header intent](https://nifti.nimh.nih.gov/pub/dist/src/niftilib/nifti1.h) is `NIFTI_INTENT_LABEL ` (1002). For example, the atlaes supplied with MRIcroGL
 - Option isAtlasOutline determines if atlas is drawn as an outline ([issue 213](https://github.com/niivue/niivue/issues/213)).
 - Similar to MRIcroGL, label colors repeat after 100 (e.g. same colors repeat for indices 1..100, 101..200, 201..300). The color should really be set to `Random`. @hanayik if someone drags-and-drops a NIfTI image onto NiiVue, it starts with the default color scheme `gray`: can you change this to default to `random` if the intent code is 1002?
 - We still need to know how to include the label names, e.g. 1Left Inferior Parietal Lobe`. MRIcroGL includes this text in the NIfTI header, between the 352 byte binary header and the image data. Maybe @cdrake's work on the AFNI extensions can be extended to support this (MRIcroGL requires three features to detect this: the `regular` character is 98 (not the typical 114), the intent is labels, and the vox_offset is greater than 352.
 - At the moment only UINT8 images are supported, easy to extend to other integer data types (e.g. INIA19 Primate Brain Atlas).


![VX2](https://user-images.githubusercontent.com/8930807/155430529-e7a4bfb3-b043-4db9-a7d5-d686b6c7db72.jpg)

