### PR TITLE
Packaging fix for `niivue doesn't appear to be written in CJS` when imported into Vite / SSR projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,13 @@
   "description": "minimal webgl2 nifti image viewer",
   "main": "./src/niivue.js",
   "unpkg": "./dist/niivue.umd.js",
+  "module": "./dist/niivue.es.js",
+  "exports": {
+    ".": {
+      "require": "./dist/niivue.umd.js",
+      "import": "./dist/niivue.es.js"
+    }
+  },
   "scripts": {
     "dev": "vite",
     "build": "npx prettier --write src/ && npx vite build --emptyOutDir --base=./ && npm run copy-test && npm run copy-demo",


### PR DESCRIPTION
Including niivue in OpenNeuro (which uses Vite and SSR so needs CJS and ESM entrypoints) encounters this warning:

```
@niivue/niivue doesn't appear to be written in CJS, but also doesn't appear to be a valid ES module (i.e. it doesn't have "type": "module" or an .mjs extension for the entry point). Please contact the package author to fix.
```

This should fix this by adding export mappings [borrowed from the building for libraries example in Vite's docs](https://vitejs.dev/guide/build.html#library-mode).