### PR TITLE
BF: Avoid use of continue statement in raycast loop, to work around apparent mesa bug

### DIFF
--- a/src/shader-srcs.js
+++ b/src/shader-srcs.js
@@ -130,12 +130,13 @@ void main() {
 	while (samplePos.a <= len) {
 		vec4 colorSample = texture(volume, samplePos.xyz);
 		samplePos += deltaDir; //advance ray position
-		if (colorSample.a < 0.01) continue;
-		if (firstHit.a > lenNoClip)
-			firstHit = samplePos;
-		backNearest = min(backNearest, samplePos.a);
-		if (colorSample.a > colAcc.a) //ties generate errors for TT_desai_dd_mpm
-			colAcc = vec4(colorSample.rgb, colorSample.a+0.00001);
+		if (colorSample.a >= 0.01) {
+			if (firstHit.a > lenNoClip)
+				firstHit = samplePos;
+			backNearest = min(backNearest, samplePos.a);
+			if (colorSample.a > colAcc.a) //ties generate errors for TT_desai_dd_mpm
+				colAcc = vec4(colorSample.rgb, colorSample.a+0.00001);
+		}
 	}
 	if (firstHit.a < len)
 		gl_FragDepth = frac2ndc(firstHit.xyz);
@@ -171,15 +172,16 @@ void main() {
 	while (samplePos.a <= len) {
 		vec4 colorSample = texture(overlay, samplePos.xyz);
 		samplePos += deltaDir; //advance ray position
-		if (colorSample.a < 0.01) continue;
-		if (overFirstHit.a > len)
-			overFirstHit = samplePos;
-		colorSample.a = 1.0-pow((1.0 - colorSample.a), opacityCorrection);
-		colorSample.rgb *= colorSample.a;
-		colAcc= (1.0 - colAcc.a) * colorSample + colAcc;
-		overFarthest = samplePos.a;
-		if ( colAcc.a > earlyTermination )
-			break;
+		if (colorSample.a >= 0.01) {
+			if (overFirstHit.a > len)
+				overFirstHit = samplePos;
+			colorSample.a = 1.0-pow((1.0 - colorSample.a), opacityCorrection);
+			colorSample.rgb *= colorSample.a;
+			colAcc= (1.0 - colAcc.a) * colorSample + colAcc;
+			overFarthest = samplePos.a;
+			if ( colAcc.a > earlyTermination )
+				break;
+		}
 	}
 	if (overFirstHit.a < firstHit.a)
 	//if (overFirstHit.a < len)

--- a/src/shader-srcs.js
+++ b/src/shader-srcs.js
@@ -293,15 +293,16 @@ void main() {
 	while (samplePos.a <= len) {
 		vec4 colorSample = texture(volume, samplePos.xyz);
 		samplePos += deltaDir; //advance ray position
-		if (colorSample.a < 0.01) continue;
-		if (firstHit.a > lenNoClip)
-			firstHit = samplePos;
-		backNearest = min(backNearest, samplePos.a);
-		colorSample.a = 1.0-pow((1.0 - colorSample.a), opacityCorrection);
-		colorSample.rgb *= colorSample.a;
-		colAcc= (1.0 - colAcc.a) * colorSample + colAcc;
-		if ( colAcc.a > earlyTermination )
-			break;
+		if (colorSample.a >= 0.01) {
+			if (firstHit.a > lenNoClip)
+				firstHit = samplePos;
+			backNearest = min(backNearest, samplePos.a);
+			colorSample.a = 1.0-pow((1.0 - colorSample.a), opacityCorrection);
+			colorSample.rgb *= colorSample.a;
+			colAcc= (1.0 - colAcc.a) * colorSample + colAcc;
+			if ( colAcc.a > earlyTermination )
+				break;
+		}
 	}
 	if (firstHit.a < len)
 		gl_FragDepth = frac2ndc(firstHit.xyz);
@@ -341,15 +342,16 @@ void main() {
 	while (samplePos.a <= len) {
 		vec4 colorSample = texture(overlay, samplePos.xyz);
 		samplePos += deltaDir; //advance ray position
-		if (colorSample.a < 0.01) continue;
-		if (overFirstHit.a > len)
-			overFirstHit = samplePos;
-		colorSample.a = 1.0-pow((1.0 - colorSample.a), opacityCorrection);
-		colorSample.rgb *= colorSample.a;
-		colAcc= (1.0 - colAcc.a) * colorSample + colAcc;
-		overFarthest = samplePos.a;
-		if ( colAcc.a > earlyTermination )
-			break;
+		if (colorSample.a >= 0.01) {
+			if (overFirstHit.a > len)
+				overFirstHit = samplePos;
+			colorSample.a = 1.0-pow((1.0 - colorSample.a), opacityCorrection);
+			colorSample.rgb *= colorSample.a;
+			colAcc= (1.0 - colAcc.a) * colorSample + colAcc;
+			overFarthest = samplePos.a;
+			if ( colAcc.a > earlyTermination )
+				break;
+		}
 	}
 	if (samplePos.a >= len) {
 		if (isClip && (fColor.a == 0.0))


### PR DESCRIPTION
This PR fixes the artifact reported in #344. 

However, I don't know enough about the niivue internals to understand the ramifications of removing these clauses.  Specifically, I don't know where the `<voxel intensity>->RGBA` transfer function is defined, nor what the resulting alpha values represent.  These clauses were present in the very first commit on the niivue/niivue github repository, so there is no provenance as to what they intend to accomplish. @neurolabusc, do you have any insight here?

List of fixed issues (if they exist):

- #344 

Demos work on:

- [ ] iOS Safari
- [ ] iOS Firefox
- [ ] iOS Chrome
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] macOS Safari
- [ ] macOS Firefox
- [ ] macOS Chrome
- [ ] Windows Chrome
- [ ] Windows 

