### PR TITLE
Little fixes

### DIFF
--- a/demos/features/sync.mesh.html
+++ b/demos/features/sync.mesh.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <title>sync 3d</title>
+    <style>
+      section {
+        margin: 20px;
+      }
+    </style>
+  </head>
+  <body style="font-family: sans-serif;">
+    <noscript>
+      <strong>niivue doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+    </noscript>
+
+    <section>
+      <h1>
+        Sync 3D
+      </h1>
+      <p>
+        The first canvas can control the second one. The second canvas can be controlled separately from the first. 
+      </p>
+      <input type="checkbox" id="check10" name="check10" unchecked>
+      <label for="check10">HighDPI</label>
+    </section>
+
+    <!-- demo 1 -->
+    <section>
+      <div id="demo1" style="width:90%; height:400px;">
+        <canvas id="gl1" height=480 width=640>
+        </canvas>
+      </div>
+    </section>
+
+    <!-- demo 2 -->
+    <section>
+      <div id="demo2" style="width:90%; height:400px;">
+        <canvas id="gl2" height=480 width=480>
+        </canvas>
+      </div>
+    </section>
+    
+
+    <script src="./niivue.umd.js">
+    </script>
+    <script>
+      document.getElementById("check10").addEventListener("change", doCheck10Click);
+      function doCheck10Click() {
+        nv1.setHighResolutionCapable(this.checked);
+      }
+      var nv1 = new niivue.Niivue({backColor: [1, 1, 1, 1]})
+      nv1.attachTo('gl1')
+      nv1.setHighResolutionCapable(false)
+      nv1.setMeshShader('Outline')
+      nv1.opts.isOrientCube = true
+      nv1.loadMeshes([
+         {url: "../images/BrainMesh_ICBM152.lh.mz3"},
+      ])
+      nv1.setSliceType(nv1.sliceTypeRender)
+      var nv2 = new niivue.Niivue({backColor: [1, 1, 1, 1]})
+      nv2.attachTo('gl2')
+      nv2.setHighResolutionCapable(true)
+      nv2.setMeshShader('Outline')
+      nv2.opts.isOrientCube = true
+      nv2.loadMeshes([
+         {url: "../images/BrainMesh_ICBM152.lh.mz3"},
+      ])
+      nv2.setSliceType(nv2.sliceTypeRender)
+      nv1.syncWith(nv2, {'3d':true, '2d':false})
+    </script>
+  </body>
+</html>

--- a/demos/index.html
+++ b/demos/index.html
@@ -56,6 +56,9 @@
       <a href="./features/sync.3d.html" target="_blank" rel="noopener noreferrer">Sync 3D</a>
     </section>
     <section>
+      <a href="./features/sync.mesh.html" target="_blank" rel="noopener noreferrer">Sync mesh</a>
+    </section>
+    <section>
       <a href="./features/sync.3dplanar.html" target="_blank" rel="noopener noreferrer">Sync 3D with planar</a>
     </section>
     <section>

--- a/src/niivue.js
+++ b/src/niivue.js
@@ -60,7 +60,7 @@ import { Log } from "./logger";
 import defaultFontPNG from "./fonts/Roboto-Regular.png";
 import defaultFontMetrics from "./fonts/Roboto-Regular.json";
 import { colortables } from "./colortables";
-export {colortables} from './colortables'
+export { colortables } from "./colortables";
 import { webSocket } from "rxjs/webSocket";
 import { interval } from "rxjs";
 


### PR DESCRIPTION
List of fixed issues:

- 3D crosshairs influenced by `crosshairWidth`
- 2D world space views show crosshairs regardless of `show3Dcrosshair`
- multiplanarPadPixels generates console message if non-numeric value is supplied and uses parseFloat() to convert strings to numbers. In general, user interfaces should supply numeric values to parameters, not strings. In other words, the text string "3" is not the same as the number 3.


