### PR TITLE
Disable cull face for mirror-flipped statistics

### DIFF
--- a/src/niivue.css
+++ b/src/niivue.css
@@ -1,7 +1,7 @@
 html {
-    height: auto;
-    min-height: 100%;
-    margin: 0;
+  height: auto;
+  min-height: 100%;
+  margin: 0;
 }
 body {
   display: flex;

--- a/src/niivue.js
+++ b/src/niivue.js
@@ -619,7 +619,7 @@ Niivue.prototype.resizeListener = function () {
   //https://www.khronos.org/webgl/wiki/HandlingHighDPI
   if (this.opts.isHighResolutionCapable) {
     this.uiData.dpr = window.devicePixelRatio || 1;
-    console.log("devicePixelRatio: " + this.uiData.dpr);
+    //console.log("devicePixelRatio: " + this.uiData.dpr);
   } else {
     this.uiData.dpr = 1;
   }
@@ -5582,6 +5582,7 @@ Niivue.prototype.drawColorbarCore = function (
     this.gl.canvas.width,
     this.gl.canvas.height,
   ]);
+  this.gl.disable(this.gl.CULL_FACE);
   if (isNegativeColor) {
     let flip = [barLTWH[0] + barLTWH[2], barLTWH[1], -barLTWH[2], barLTWH[3]];
     this.gl.uniform4fv(this.colorbarShader.leftTopWidthHeightLoc, flip);


### PR DESCRIPTION
List of fixed issues (if they exist):

- The last PR flips negative colorbars so the left side is brighter (like AFNI, FSLeyes and BrainVoyager, but unlike MRIcroGL. Depending on screen size, this could lead to the [alphathreshold demo](https://niivue.github.io/niivue/features/alphathreshold.html) not showing the colorbar. This PR disables CULL_FACE to fix this problem.
