### PR TITLE
Bump nifti reader js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@niivue/niivue",
-  "version": "0.33.1",
+  "version": "0.33.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@niivue/niivue",
-      "version": "0.33.1",
+      "version": "0.33.2",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@ungap/structured-clone": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "daikon": "^1.2.43",
         "fflate": "^0.7.4",
         "gl-matrix": "^3.4.3",
-        "nifti-reader-js": "^0.6.2",
+        "nifti-reader-js": "^0.6.4",
         "rxjs": "^7.8.0",
         "uuid": "^9.0.0"
       },
@@ -5434,9 +5434,9 @@
       }
     },
     "node_modules/nifti-reader-js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/nifti-reader-js/-/nifti-reader-js-0.6.2.tgz",
-      "integrity": "sha512-fluTwDC+U8AsZc7t3boqd+JzcGg0LFcrlsD3iYi7BMbO54PfdPAtsWCiwFJgVb5jQ7H1GsYtWqy+qYN5zHFUcA==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/nifti-reader-js/-/nifti-reader-js-0.6.4.tgz",
+      "integrity": "sha512-n31xv7a8VGChPfmxzYSln0id9bbr3VPKko3LkBwGXx9PqwGugKjxuddPqGJ2LqPePmaTVBCcLIWwR2GN6zwnDw==",
       "dependencies": {
         "fflate": "*"
       }
@@ -11643,9 +11643,9 @@
       "dev": true
     },
     "nifti-reader-js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/nifti-reader-js/-/nifti-reader-js-0.6.2.tgz",
-      "integrity": "sha512-fluTwDC+U8AsZc7t3boqd+JzcGg0LFcrlsD3iYi7BMbO54PfdPAtsWCiwFJgVb5jQ7H1GsYtWqy+qYN5zHFUcA==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/nifti-reader-js/-/nifti-reader-js-0.6.4.tgz",
+      "integrity": "sha512-n31xv7a8VGChPfmxzYSln0id9bbr3VPKko3LkBwGXx9PqwGugKjxuddPqGJ2LqPePmaTVBCcLIWwR2GN6zwnDw==",
       "requires": {
         "fflate": "*"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@niivue/niivue",
-  "version": "0.33.1",
+  "version": "0.33.2",
   "description": "minimal webgl2 nifti image viewer",
   "main": "./src/niivue.js",
   "unpkg": "./dist/niivue.umd.js",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "daikon": "^1.2.43",
     "fflate": "^0.7.4",
     "gl-matrix": "^3.4.3",
-    "nifti-reader-js": "^0.6.2",
+    "nifti-reader-js": "^0.6.4",
     "rxjs": "^7.8.0",
     "uuid": "^9.0.0"
   },


### PR DESCRIPTION
List of fixed issues (if they exist):

- bump nifti reader js version to reflect latest changes (0.6.4)

