### PR TITLE
Mnt/bump nifti reader js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@niivue/niivue",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@niivue/niivue",
-      "version": "0.34.0",
+      "version": "0.34.1",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@ungap/structured-clone": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "daikon": "^1.2.43",
         "fflate": "^0.7.4",
         "gl-matrix": "^3.4.3",
-        "nifti-reader-js": "^0.6.4",
+        "nifti-reader-js": "^0.6.5",
         "rxjs": "^7.8.0",
         "uuid": "^9.0.0"
       },
@@ -5434,9 +5434,9 @@
       }
     },
     "node_modules/nifti-reader-js": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/nifti-reader-js/-/nifti-reader-js-0.6.4.tgz",
-      "integrity": "sha512-n31xv7a8VGChPfmxzYSln0id9bbr3VPKko3LkBwGXx9PqwGugKjxuddPqGJ2LqPePmaTVBCcLIWwR2GN6zwnDw==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/nifti-reader-js/-/nifti-reader-js-0.6.5.tgz",
+      "integrity": "sha512-1s1EcsTQDPpO5XlDSB/qdRJJAPhttC6CkfK9K4ARxNqtAuhYVP69kJH3N75p0ZqHoCalwy5UDMB0+7ee2WnsYQ==",
       "dependencies": {
         "fflate": "*"
       }
@@ -11643,9 +11643,9 @@
       "dev": true
     },
     "nifti-reader-js": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/nifti-reader-js/-/nifti-reader-js-0.6.4.tgz",
-      "integrity": "sha512-n31xv7a8VGChPfmxzYSln0id9bbr3VPKko3LkBwGXx9PqwGugKjxuddPqGJ2LqPePmaTVBCcLIWwR2GN6zwnDw==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/nifti-reader-js/-/nifti-reader-js-0.6.5.tgz",
+      "integrity": "sha512-1s1EcsTQDPpO5XlDSB/qdRJJAPhttC6CkfK9K4ARxNqtAuhYVP69kJH3N75p0ZqHoCalwy5UDMB0+7ee2WnsYQ==",
       "requires": {
         "fflate": "*"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@niivue/niivue",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "description": "minimal webgl2 nifti image viewer",
   "main": "./src/niivue.js",
   "unpkg": "./dist/niivue.umd.js",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "daikon": "^1.2.43",
     "fflate": "^0.7.4",
     "gl-matrix": "^3.4.3",
-    "nifti-reader-js": "^0.6.4",
+    "nifti-reader-js": "^0.6.5",
     "rxjs": "^7.8.0",
     "uuid": "^9.0.0"
   },


### PR DESCRIPTION
List of fixed issues (if they exist):

- bump nifti-reader-js to [latest version](https://github.com/rii-mango/NIFTI-Reader-JS/pull/30) that uses TS

