### PR TITLE
Close fiberGroupColormap when setting a non-group color scheme

### DIFF
--- a/demos/features/tracts.group.html
+++ b/demos/features/tracts.group.html
@@ -81,6 +81,7 @@
       };
       nv1.setMeshProperty(nv1.meshes[0].id, "fiberGroupColormap", cmap);
     } else {
+      nv1.setMeshProperty(nv1.meshes[0].id, "fiberGroupColormap", null);
       nv1.setMeshProperty(nv1.meshes[0].id, "fiberColor", colorName);
     }
   };


### PR DESCRIPTION
List of fixed issues (if they exist):

- This fixes a bug with the [new fiber group live demo](https://niivue.github.io/niivue/features/tracts.group.html). After setting a group coloring, you need to unset the group coloring to apply a whole-tract color mechanism.
