### PR TITLE
add two stage build to inject niivue UMD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules
 /dist
+dist_intermediate
 devdocs
 /_md_docs
 /docs/niivue*.js

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "npx prettier --write src/ && npx vite build --emptyOutDir --base=./ && npm run copy-test && npm run copy-demo",
-    "build-win": "npx prettier --write src/ && npx vite build --emptyOutDir && npm run copy-test-win && npm run copy-demo-win",
+    "build": "npx prettier --write src/ && npx vite build --config vite.config.js --emptyOutDir --base=./ && vite build --config vite.config_inject.js --emptyOutDir --base=./ && npm run copy-test && npm run copy-demo",
+    "build-win": "npx prettier --write src/ && npx vite build --config vite.config.js --emptyOutDir && vite build --config vite.config_inject.js --emptyOutDir && npm run copy-test-win && npm run copy-demo-win",
     "demo": "npm run build && npx http-server demos/ --cors",
     "demo-win": "npm run build-win && npx http-server demos/",
     "copy-test": "cp ./dist/niivue.umd.js ./tests/niivue.umd.js",

--- a/src/niivue.js
+++ b/src/niivue.js
@@ -774,7 +774,6 @@ Niivue.prototype.decodeEmbeddedUMD = function () {
   let decompressedBuffer = fflate.decompressSync(compressedView);
   // convert the array buffer to a string
   let decompressed = new TextDecoder("utf-8").decode(decompressedBuffer);
-  // eval the string to get the umd code
   // console.log(decompressed);
   return decompressed;
 };

--- a/src/niivue.js
+++ b/src/niivue.js
@@ -1,5 +1,6 @@
 import { Shader } from "./shader.js";
 import * as mat from "gl-matrix";
+import * as fflate from "fflate";
 import {
   vertOrientCubeShader,
   fragOrientCubeShader,
@@ -744,6 +745,38 @@ Niivue.prototype.off = function (event) {
       return;
     }
   }
+};
+
+/**
+ * decode the compressed embedded UMD string of the bundled Niivue code
+ * @param {string} umdBase64 the base64 encoded compressed UMD string
+ * @returns {string} the uncompressed UMD string
+ * @example
+ * niivue = new Niivue()
+ * niivue.decodeEmbeddedUMD()
+ */
+Niivue.prototype.decodeEmbeddedUMD = function () {
+  let UMD_AVAIL = typeof __NIIVUE_UMD__ === "undefined" ? false : true;
+  if (!UMD_AVAIL) {
+    return "";
+  }
+  let umdBase64 = __NIIVUE_UMD__;
+  // use fflate to decompress the compressed base64 string.
+  // undo the base64 encoding
+  let compressed = atob(umdBase64);
+  // convert to an array buffer
+  let compressedBuffer = new ArrayBuffer(compressed.length);
+  let compressedView = new Uint8Array(compressedBuffer);
+  for (let i = 0; i < compressed.length; i++) {
+    compressedView[i] = compressed.charCodeAt(i);
+  }
+  // decompress the array buffer
+  let decompressedBuffer = fflate.decompressSync(compressedView);
+  // convert the array buffer to a string
+  let decompressed = new TextDecoder("utf-8").decode(decompressedBuffer);
+  // eval the string to get the umd code
+  // console.log(decompressed);
+  return decompressed;
 };
 
 /**

--- a/tests/test.embedUMD.js
+++ b/tests/test.embedUMD.js
@@ -1,0 +1,13 @@
+const { httpServerAddress } = require("./helpers");
+beforeEach(async () => {
+  await page.goto(httpServerAddress, { timeout: 0 });
+  await page.setViewport({ width: 1440, height: 900, deviceScaleFactor: 1 });
+});
+test("embedUMD", async () => {
+  let umd = await page.evaluate(async () => {
+    nv = new niivue.Niivue();
+    return nv.decodeEmbeddedUMD(); 
+  });
+  expect(umd.trim().endsWith("{value:\"Module\"})});")).toBe(true);
+  
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -22,7 +22,7 @@ module.exports = defineConfig({
     include: /node_modules/,
   })],
   build: {
-    outDir: "./dist",
+    outDir: "./dist_intermediate",
     lib: {
       entry: path.resolve(__dirname, "src/niivue.js"),
       name: "niivue",

--- a/vite.config_inject.js
+++ b/vite.config_inject.js
@@ -1,0 +1,54 @@
+// vite.config.js
+const path = require("path");
+const { defineConfig } = require("vite");
+const fs = require("fs");
+const zlib = require("zlib");
+import commonjs from "@rollup/plugin-commonjs";
+
+// function that reads the text contents of ./dist/niivue.umd.js as a string.
+// that string is then injected into the __NIIVUE_UMD__ variable in the
+// bundle. This allows niivue to inject itself into html pages constructed
+// by saveAsHtml.
+function readAndZipNiivueUmd() {
+  let niivueUmd = fs.readFileSync("./dist_intermediate/niivue.umd.js", "utf8");
+  // use nodejs zlib to compress the string
+    const compressed = zlib.deflateSync(niivueUmd);
+    // convert to base64
+    const base64 = compressed.toString("base64");
+    // console.log(base64)
+    // convert to a string literal
+    const stringLiteral = String.raw`${base64}`;
+    // return the string literal
+    return stringLiteral;
+}
+
+const niivueUmd = readAndZipNiivueUmd();
+
+module.exports = defineConfig({
+  define: {
+    __NIIVUE_VERSION__: JSON.stringify(process.env.npm_package_version),
+    __NIIVUE_UMD__: JSON.stringify(niivueUmd),
+  },
+  root: ".",
+  server: {
+    open: "/src/index.html",
+    fs: {
+      // Allow serving files from one level up to the project root
+      allow: [".."],
+    },
+  },
+  optimizeDeps: {
+    include: ['nifti-reader-js'],
+  },
+  plugins: [commonjs({
+    include: /node_modules/,
+  })],
+  build: {
+    outDir: "./dist",
+    lib: {
+      entry: path.resolve(__dirname, "src/niivue.js"),
+      name: "niivue",
+      fileName: (format) => `niivue.${format}.js`,
+    },
+  },
+});


### PR DESCRIPTION
List of fixed issues (if they exist):

- related to #682 and #680 
- added a new vite config file to embed the previously bundled niivue UMD (now a two stage build process)
- the new build process does this:

1.   first pass builds niivue.es.js and niivue.umd.js
2. second pass reads the contents of niivue.umd.js via the new vite config file and injects the base64 encoded, compressed version of niivue.umd.js
3. The build is actually not as large as estimated, so the size cost of doing this is negligible 

- added a new function to niivue: `decodeEmbeddedUMD()`. This function will decode the base64 string and decompress the embedded Niivue UMD bundle so that the string contents can be injected into HTML files that Niivue saves.
- To try it, you can put `console.log(this.decodeEmbeddedUMD());` inside `attachToCanvas` to see the contents of the UMD version of niivue printed in the console.
