### PR TITLE
Fix DICOM scaling

### DIFF
--- a/src/nvimage.js
+++ b/src/nvimage.js
@@ -953,10 +953,18 @@ NVImage.prototype.readDICOM = function (buf) {
   let rc = this.series.images[0].getPixelSpacing(); //TODO: order?
   hdr.pixDims[1] = rc[0];
   hdr.pixDims[2] = rc[1];
-  hdr.pixDims[3] = Math.max(
-    this.series.images[0].getSliceGap(),
-    this.series.images[0].getSliceThickness()
-  );
+  if (this.series.images.length > 1) {
+    // Multiple slices. The depth of a pixel is the physical distance between offsets. This is not the same as slice
+    // spacing for tilted slices (skew).
+    let p0 = vec3.fromValues(...this.series.images[0].getImagePosition());
+    let p1 = vec3.fromValues(...this.series.images[1].getImagePosition());
+    let n = vec3.fromValues(0, 0, 0);
+    vec3.subtract(n, p0, p1);
+    hdr.pixDims[3] = vec3.length(n);
+  } else {
+    // Single slice. Use the slice thickness as pixel depth.
+    hdr.pixDims[3] = this.series.images[0].getSliceThickness();
+  }
   hdr.pixDims[4] = this.series.images[0].getTR() / 1000.0; //msec -> sec
   let dt = this.series.images[0].getDataType(); //2=int,3=uint,4=float,
   let bpv = this.series.images[0].getBitsAllocated();


### PR DESCRIPTION
List of fixed issues:
- The DICOM slice thickness was used as pixel depth, but the pixel depth should be calculated using the offsets between subsequent slices. The slice thickness is frequently larger than the slice spacing, and in case of tilted slices (used in helical CT's, for example), the pixel depth is larger than the slice spacing because of the skew.
