### PR TITLE
Accelerate TRK and TCK loading

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -104,7 +104,6 @@
       function doReset() {
         nv1.setDefaults(defaults, true);
       }
-      await nv1.loadMeshes([{ url: "./ILF_L.tt.gz"}]);
     </script>
   </body>
 </html>

--- a/src/nvmesh-loaders.ts
+++ b/src/nvmesh-loaders.ts
@@ -515,9 +515,13 @@ export class NVMeshLoaders {
     const reader = new DataView(buffer)
     // read and transform vertex positions
     let npt = 0
-    const offsetPt0 = []
-    offsetPt0.push(npt) // 1st streamline starts at 0
-    const pts = []
+    //over-provision offset array to store number of segments
+    let offsetPt0 = new Uint32Array(len / (4 * 4));
+    let noffset = 0;
+    //over-provision points array to store vertex positions
+    let npt3 = 0;
+    let pts = new Float32Array(len / 4);
+    offsetPt0[0] = 0; //1st streamline starts at 0
     while (pos + 12 < len) {
       const ptx = reader.getFloat32(pos, true)
       pos += 4
@@ -527,18 +531,21 @@ export class NVMeshLoaders {
       pos += 4
       if (!isFinite(ptx)) {
         // both NaN and Infinity are not finite
-        offsetPt0.push(npt)
+        offsetPt0[noffset++] = npt;
         if (!isNaN(ptx)) {
           // terminate if infinity
           break
         }
       } else {
-        pts.push(ptx)
-        pts.push(pty)
-        pts.push(ptz)
+        pts[npt3++] = ptx;
+        pts[npt3++] = pty;
+        pts[npt3++] = ptz;
         npt++
       }
     }
+    //resize offset/vertex arrays that were initially over-provisioned
+    pts = pts.slice(0, npt3);
+    offsetPt0 = offsetPt0.slice(0, noffset); 
     return {
       pts,
       offsetPt0
@@ -646,20 +653,24 @@ export class NVMeshLoaders {
     // read and transform vertex positions
     let i = 0
     let npt = 0
-    const offsetPt0 = []
-    const pts = []
+    //pre-allocate and over-provision offset array
+    let offsetPt0 = new Uint32Array(i32.length / 4);
+    let noffset = 0;;
+    //pre-allocate and over-provision vertex positions array
+    let pts = new Float32Array(i32.length);
+    let npt3 = 0;
     while (i < ntracks) {
       const n_pts = i32[i]
       i = i + 1 // read 1 32-bit integer for number of points in this streamline
-      offsetPt0.push(npt) // index of first vertex in this streamline
+      offsetPt0[noffset++] = npt;
       for (let j = 0; j < n_pts; j++) {
         const ptx = f32[i + 0]
         const pty = f32[i + 1]
         const ptz = f32[i + 2]
         i += 3 // read 3 32-bit floats for XYZ position
-        pts.push(ptx * vox2mmMat[0] + pty * vox2mmMat[1] + ptz * vox2mmMat[2] + vox2mmMat[3])
-        pts.push(ptx * vox2mmMat[4] + pty * vox2mmMat[5] + ptz * vox2mmMat[6] + vox2mmMat[7])
-        pts.push(ptx * vox2mmMat[8] + pty * vox2mmMat[9] + ptz * vox2mmMat[10] + vox2mmMat[11])
+        pts[npt3++] = ptx * vox2mmMat[0] + pty * vox2mmMat[1] + ptz * vox2mmMat[2] + vox2mmMat[3]
+        pts[npt3++] = ptx * vox2mmMat[4] + pty * vox2mmMat[5] + ptz * vox2mmMat[6] + vox2mmMat[7]
+        pts[npt3++] =ptx * vox2mmMat[8] + pty * vox2mmMat[9] + ptz * vox2mmMat[10] + vox2mmMat[11]
         if (n_scalars > 0) {
           for (let s = 0; s < n_scalars; s++) {
             dpv[s].vals.push(f32[i])
@@ -675,7 +686,11 @@ export class NVMeshLoaders {
         }
       }
     } // for each streamline: while i < n_count
-    offsetPt0.push(npt) // add 'first index' as if one more line was added (fence post problem)
+    //add 'first index' as if one more line was added (fence post problem)
+    offsetPt0[noffset++] = npt;
+    //resize offset/vertex arrays that were initially over-provisioned
+    pts = pts.slice(0, npt3);
+    offsetPt0 = offsetPt0.slice(0, noffset); 
     return {
       pts,
       offsetPt0,

--- a/src/nvmesh.ts
+++ b/src/nvmesh.ts
@@ -6,7 +6,7 @@ import { ColorMap, LUT, cmapper } from './colortables.js'
 import { NVMeshUtilities } from './nvmesh-utilities.js'
 import { NVMeshLoaders } from './nvmesh-loaders.js'
 import { LegacyConnectome, LegacyNodes, NVConnectomeEdge, NVConnectomeNode, Point } from './types.js'
-import { ANNOT, DefaultMeshType, GII, MGH, MZ3, TCK, TRACT, TRK, TRX, VTK, ValuesArray, X3D } from './nvmesh-types.js'
+import { ANNOT, DefaultMeshType, GII, MGH, MZ3, TCK, TRACT, TRK, TT, TRX, VTK, ValuesArray, X3D } from './nvmesh-types.js'
 
 /** Enum for text alignment
  */
@@ -1120,7 +1120,7 @@ export class NVMesh {
     let tris: number[] = []
     let pts: number[] = []
     let anatomicalStructurePrimary = ''
-    let obj: TCK | TRACT | TRX | TRK | GII | MZ3 | X3D | VTK | DefaultMeshType
+    let obj: TCK | TRACT | TT | TRX | TRK | GII | MZ3 | X3D | VTK | DefaultMeshType
     const re = /(?:\.([^.]+))?$/
     let ext = re.exec(name)![1]
     ext = ext.toUpperCase()
@@ -1625,6 +1625,10 @@ export class NVMesh {
 
   static readTCK(buffer: ArrayBuffer): TCK {
     return NVMeshLoaders.readTCK(buffer)
+  }
+
+  static readTT(buffer: ArrayBuffer): TT {
+    return NVMeshLoaders.readTRX(buffer)
   }
 
   static readTRX(buffer: ArrayBuffer): TRX {


### PR DESCRIPTION
List of fixed issues (if they exist):

- This [doubles the speed](https://github.com/neurolabusc/trx-javascript/tree/main) for loading TRK and TCK format tractography data
- @jens-ox the new javascript code runs, but the TypeScript generates errors as the functions return vertices are of type `Float32Array` rather than `number[]` and offsets of of type `Uint32Array` rather than `number[]`. My own sense is that **all** tractography data types (TRACT, TT, TRX, TRK, TCK, and VTK) should return these typed arrays. Do you have a strong opinion on this?
