### PR TITLE
Refactor niivue functions to child objects

### DIFF
--- a/src/niivue/index.ts
+++ b/src/niivue/index.ts
@@ -8633,7 +8633,7 @@ export class Niivue {
     if (this.volumes.length <= volIdx) {
       return [0, 0, 0]
     }
-    
+
     return this.volumes[volIdx].convertFrac2Vox(frac)
   }
 

--- a/src/niivue/index.ts
+++ b/src/niivue/index.ts
@@ -8618,45 +8618,12 @@ export class Niivue {
       }
       return frac
     }
-    // convert from object space in millimeters to normalized texture space XYZ= [0..1, 0..1 ,0..1]
-    const mm4 = vec4.fromValues(mm[0], mm[1], mm[2], 1)
-    const d = this.volumes[volIdx].dimsRAS
-    const frac = vec3.fromValues(0, 0, 0)
-    if (typeof d === 'undefined') {
-      return frac
-    }
-    if (!isForceSliceMM && !this.opts.isSliceMM) {
-      const xform = mat4.clone(this.volumes[volIdx].frac2mmOrtho!)
-      mat4.invert(xform, xform)
-      vec4.transformMat4(mm4, mm4, xform)
-      frac[0] = mm4[0]
-      frac[1] = mm4[1]
-      frac[2] = mm4[2]
-      return frac
-    }
-    if (d[1] < 1 || d[2] < 1 || d[3] < 1) {
-      return frac
-    }
-    const sform = mat4.clone(this.volumes[volIdx].matRAS!)
-    mat4.invert(sform, sform)
-    mat4.transpose(sform, sform)
-    vec4.transformMat4(mm4, mm4, sform)
-    frac[0] = (mm4[0] + 0.5) / d[1]
-    frac[1] = (mm4[1] + 0.5) / d[2]
-    frac[2] = (mm4[2] + 0.5) / d[3]
-    return frac
+    return this.volumes[volIdx].convertMM2Frac(mm, isForceSliceMM || this.opts.isSliceMM)
   }
 
   // not included in public docs
   vox2frac(vox: vec3, volIdx = 0): vec3 {
-    // convert from  0-index voxel space [0..dim[1]-1, 0..dim[2]-1, 0..dim[3]-1] to normalized texture space XYZ= [0..1, 0..1 ,0..1]
-    // consider dimension with 3 voxels, the voxel centers are at 0.25, 0.5, 0.75 corresponding to 0,1,2
-    const frac = vec3.fromValues(
-      (vox[0] + 0.5) / this.volumes[volIdx].dimsRAS![1],
-      (vox[1] + 0.5) / this.volumes[volIdx].dimsRAS![2],
-      (vox[2] + 0.5) / this.volumes[volIdx].dimsRAS![3]
-    )
-    return frac
+    return this.volumes[volIdx].convertVox2Frac(vox)
   }
 
   // not included in public docs
@@ -8666,12 +8633,8 @@ export class Niivue {
     if (this.volumes.length <= volIdx) {
       return [0, 0, 0]
     }
-    const vox = vec3.fromValues(
-      Math.round(frac[0] * this.volumes[volIdx].dims![1] - 0.5), // dims === RAS
-      Math.round(frac[1] * this.volumes[volIdx].dims![2] - 0.5), // dims === RAS
-      Math.round(frac[2] * this.volumes[volIdx].dims![3] - 0.5) // dims === RAS
-    )
-    return vox
+    
+    return this.volumes[volIdx].convertFrac2Vox(frac)
   }
 
   /**
@@ -8699,11 +8662,7 @@ export class Niivue {
   frac2mm(frac: vec3, volIdx = 0, isForceSliceMM = false): vec4 {
     const pos = vec4.fromValues(frac[0], frac[1], frac[2], 1)
     if (this.volumes.length > 0) {
-      if (isForceSliceMM || this.opts.isSliceMM) {
-        vec4.transformMat4(pos, pos, this.volumes[volIdx].frac2mm!)
-      } else {
-        vec4.transformMat4(pos, pos, this.volumes[volIdx].frac2mmOrtho!)
-      }
+      return this.volumes[volIdx].convertFrac2MM(frac, isForceSliceMM || this.opts.isSliceMM)
     } else {
       const [mn, mx] = this.sceneExtentsMinMax()
       const lerp = (x: number, y: number, a: number): number => x * (1 - a) + y * a

--- a/src/niivue/index.ts
+++ b/src/niivue/index.ts
@@ -3349,12 +3349,7 @@ export class Niivue {
 
   // not included in public docs
   vox2mm(XYZ: number[], mtx: mat4): vec3 {
-    const sform = mat4.clone(mtx)
-    mat4.transpose(sform, sform)
-    const pos = vec4.fromValues(XYZ[0], XYZ[1], XYZ[2], 1)
-    vec4.transformMat4(pos, pos, sform)
-    const pos3 = vec3.fromValues(pos[0], pos[1], pos[2])
-    return pos3
+    return NVUtilities.vox2mm(XYZ, mtx)
   }
 
   /**

--- a/src/nvimage/index.ts
+++ b/src/nvimage/index.ts
@@ -3400,11 +3400,11 @@ export class NVImage {
   // not included in public docs
   convertFrac2MM(frac: vec3, isForceSliceMM = false): vec4 {
     const pos = vec4.fromValues(frac[0], frac[1], frac[2], 1)
-      if (isForceSliceMM) {
-        vec4.transformMat4(pos, pos, this.frac2mm!)
-      } else {
-        vec4.transformMat4(pos, pos, this.frac2mmOrtho!)
-      }
+    if (isForceSliceMM) {
+      vec4.transformMat4(pos, pos, this.frac2mm!)
+    } else {
+      vec4.transformMat4(pos, pos, this.frac2mmOrtho!)
+    }
     return pos
   }
 

--- a/src/nvimage/index.ts
+++ b/src/nvimage/index.ts
@@ -3374,4 +3374,69 @@ export class NVImage {
     odata.set(img8, hdrBytes.length + opad.length)
     return odata
   }
+
+  // not included in public docs
+  convertVox2Frac(vox: vec3): vec3 {
+    // convert from  0-index voxel space [0..dim[1]-1, 0..dim[2]-1, 0..dim[3]-1] to normalized texture space XYZ= [0..1, 0..1 ,0..1]
+    // consider dimension with 3 voxels, the voxel centers are at 0.25, 0.5, 0.75 corresponding to 0,1,2
+    const frac = vec3.fromValues(
+      (vox[0] + 0.5) / this.dimsRAS![1],
+      (vox[1] + 0.5) / this.dimsRAS![2],
+      (vox[2] + 0.5) / this.dimsRAS![3]
+    )
+    return frac
+  }
+
+  // not included in public docs
+  convertFrac2Vox(frac: vec3): vec3 {
+    const vox = vec3.fromValues(
+      Math.round(frac[0] * this.dims![1] - 0.5), // dims === RAS
+      Math.round(frac[1] * this.dims![2] - 0.5), // dims === RAS
+      Math.round(frac[2] * this.dims![3] - 0.5) // dims === RAS
+    )
+    return vox
+  }
+
+  // not included in public docs
+  convertFrac2MM(frac: vec3, isForceSliceMM = false): vec4 {
+    const pos = vec4.fromValues(frac[0], frac[1], frac[2], 1)
+      if (isForceSliceMM) {
+        vec4.transformMat4(pos, pos, this.frac2mm!)
+      } else {
+        vec4.transformMat4(pos, pos, this.frac2mmOrtho!)
+      }
+    return pos
+  }
+
+  // not included in public docs
+  convertMM2Frac(mm: vec3 | vec4, isForceSliceMM = false): vec3 {
+    // given mm, return volume fraction
+    // convert from object space in millimeters to normalized texture space XYZ= [0..1, 0..1 ,0..1]
+    const mm4 = vec4.fromValues(mm[0], mm[1], mm[2], 1)
+    const d = this.dimsRAS
+    const frac = vec3.fromValues(0, 0, 0)
+    if (typeof d === 'undefined') {
+      return frac
+    }
+    if (!isForceSliceMM) {
+      const xform = mat4.clone(this.frac2mmOrtho!)
+      mat4.invert(xform, xform)
+      vec4.transformMat4(mm4, mm4, xform)
+      frac[0] = mm4[0]
+      frac[1] = mm4[1]
+      frac[2] = mm4[2]
+      return frac
+    }
+    if (d[1] < 1 || d[2] < 1 || d[3] < 1) {
+      return frac
+    }
+    const sform = mat4.clone(this.matRAS!)
+    mat4.invert(sform, sform)
+    mat4.transpose(sform, sform)
+    vec4.transformMat4(mm4, mm4, sform)
+    frac[0] = (mm4[0] + 0.5) / d[1]
+    frac[1] = (mm4[1] + 0.5) / d[2]
+    frac[2] = (mm4[2] + 0.5) / d[3]
+    return frac
+  }
 }

--- a/src/nvutilities.ts
+++ b/src/nvutilities.ts
@@ -1,5 +1,6 @@
 import arrayEqual from 'array-equal'
 import { compressSync, decompressSync, strToU8 } from 'fflate/browser'
+import { mat4, vec3, vec4 } from 'gl-matrix'
 
 /**
  * Namespace for utility functions
@@ -162,5 +163,14 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
     ret[1] /= len
     ret[2] /= len
     return ret
+  }
+
+  static vox2mm(XYZ: number[], mtx: mat4): vec3 {
+    const sform = mat4.clone(mtx)
+    mat4.transpose(sform, sform)
+    const pos = vec4.fromValues(XYZ[0], XYZ[1], XYZ[2], 1)
+    vec4.transformMat4(pos, pos, sform)
+    const pos3 = vec3.fromValues(pos[0], pos[1], pos[2])
+    return pos3
   }
 }

--- a/src/nvutilities.ts
+++ b/src/nvutilities.ts
@@ -138,4 +138,29 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
   static range(start: number, stop: number, step: number): number[] {
     return Array.from({ length: (stop - start) / step + 1 }, (_, i) => start + i * step)
   }
+
+  /**
+   * convert spherical AZIMUTH, ELEVATION to Cartesian
+   * @param azimuth - azimuth number
+   * @param elevation - elevation number
+   * @returns the converted [x, y, z] coordinates
+   * @example
+   * xyz = NVUtilities.sph2cartDeg(42, 42)
+   */
+  static sph2cartDeg(azimuth: number, elevation: number): number[] {
+    // convert spherical AZIMUTH,ELEVATION,RANGE to Cartesion
+    // see Matlab's [x,y,z] = sph2cart(THETA,PHI,R)
+    // reverse with cart2sph
+    const Phi = -elevation * (Math.PI / 180)
+    const Theta = ((azimuth - 90) % 360) * (Math.PI / 180)
+    const ret = [Math.cos(Phi) * Math.cos(Theta), Math.cos(Phi) * Math.sin(Theta), Math.sin(Phi)]
+    const len = Math.sqrt(ret[0] * ret[0] + ret[1] * ret[1] + ret[2] * ret[2])
+    if (len <= 0.0) {
+      return ret
+    }
+    ret[0] /= len
+    ret[1] /= len
+    ret[2] /= len
+    return ret
+  }
 }

--- a/tests/unit/nvimage.test.ts
+++ b/tests/unit/nvimage.test.ts
@@ -17,3 +17,14 @@ test("nvimage convertVox2Frac", () => {
         expect(frac[i]).toBeCloseTo(expected[i])
     }
 })
+
+test("nvimage zerosLike", () => {
+    const name = "mni152.nii.gz"
+    const dataBuffer = readFileSync(path.join("./tests/images/", name))
+    const image = new NVImage(
+        dataBuffer.buffer,
+        name)
+    const zeroImage = NVImage.zerosLike(image)
+    expect(JSON.stringify(image.hdr)).toBe(JSON.stringify(zeroImage.hdr))
+    expect(zeroImage.img!.every((item: number) => item === 0)).toBeTruthy()
+})

--- a/tests/unit/nvimage.test.ts
+++ b/tests/unit/nvimage.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "vitest"
+import { NVImage } from "../../src/niivue/index.js" // note the js extension
+import { readFileSync } from 'node:fs'
+import path from 'path'
+import { vec3 } from 'gl-matrix'
+
+test("nvimage convertVox2Frac", () => {
+    const name = "mni152.nii.gz"
+    const dataBuffer = readFileSync(path.join("./tests/images/", name))
+    const image = new NVImage(
+        dataBuffer.buffer,
+        name)
+    const vox =vec3.fromValues(103, 128, 129)
+    const frac = image.convertVox2Frac(vox)
+    const expected = [0.5000415009576917, 0.5017796754837036, 0.6023715706758721]
+    for (let i = 0; i < frac.length; i++) {
+        expect(frac[i]).toBeCloseTo(expected[i])
+    }
+})

--- a/tests/unit/nvutilities.test.ts
+++ b/tests/unit/nvutilities.test.ts
@@ -1,7 +1,18 @@
 import { NVUtilities } from '../../src/niivue/index.js' // note the js extension
 import { expect, test } from "vitest"
+import { mat4 } from "gl-matrix"
 
-test('nvutilities sph2cartDe', () => {
+test('nvutilities sph2cartDeg', () => {
   const xyz = NVUtilities.sph2cartDeg(42, 42)
   expect(xyz).toEqual([0.4972609476841367, -0.5522642316338268, -0.6691306063588582])
+})
+
+test('nvutilities vox2mm', () => {
+    const vox = [103, 128, 129]
+    const xfm = mat4.fromValues(0.7375, 0, 0, -75.76, 0, 0.7375, 0, -110.8, 0, 0, 0.7375, -71.76, 0, 0, 0, 1)
+    const mm = NVUtilities.vox2mm(vox, xfm)
+    const expected = [0.20249909162521362, -16.400001525878906, 23.377498626708984]
+    for (let i = 0; i < mm.length; i++) {
+        expect(mm[i]).toBeCloseTo(expected[i])
+    }
 })

--- a/tests/unit/nvutilities.test.ts
+++ b/tests/unit/nvutilities.test.ts
@@ -1,0 +1,7 @@
+import { NVUtilities } from '../../src/niivue/index.js' // note the js extension
+import { expect, test } from "vitest"
+
+test('nvutilities sph2cartDe', () => {
+  const xyz = NVUtilities.sph2cartDeg(42, 42)
+  expect(xyz).toEqual([0.4972609476841367, -0.5522642316338268, -0.6691306063588582])
+})


### PR DESCRIPTION
List of fixed issues (if they exist):
Moved function implementations with no member data access to NVUtilities(sph2cartDeg and vox2mm) and NVImage specific functions to NVImage (vox2frac, frac2vox, mm2frac, and frac2mm) to NVImage. Left function stubs in niivue. 

Converted the following jest tests to vitest unit tests:
- test.sphere2cart.js
- test.vox2frac.js
- test.vox2mm.js
- test.zerosLike.js

