### PR TITLE
Canvas sizing in flexbox parent

### DIFF
--- a/playwright/e2e/helpers.js
+++ b/playwright/e2e/helpers.js
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync } from 'fs'
 
 export const httpServerAddress = 'http://localhost:8888/tests/index.html'
 export const httpServerAddressSync = 'http://localhost:8888/tests/sync.html'
+export const httpServerAddressFlexbox = 'http://localhost:8888/tests/flexbox.html'
 export const httpServerAddressDemos = 'http://localhost:8888/demos/features/'
 export const testOptions = {
   isAntiAlias: false,

--- a/playwright/e2e/test.niivue.flexboxResize.spec.ts
+++ b/playwright/e2e/test.niivue.flexboxResize.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * Regression test for https://github.com/niivue/niivue/issues/862
+ */
+
+import { test, expect } from '@playwright/test'
+import { Niivue } from '../../dist/index'
+import { httpServerAddressFlexbox } from './helpers'
+
+test.beforeEach(async ({ page }) => {
+  await page.setViewportSize({ width: 600, height: 600 })
+  await page.goto(httpServerAddressFlexbox)
+})
+
+test('canvas size is sized consistently in a flexbox parent', async ({ page }) => {
+  const gl = await page.evaluate(async (testOptions) => {
+    const nv = new Niivue(testOptions)
+    await nv.attachTo('gl', false)
+    return nv.gl
+  })
+  expect(gl).toBeDefined()
+
+  await page.evaluate(async () => {
+    const nv = new Niivue()
+    await nv.attachTo('gl', false)
+  })
+  await expect(page.getByText('bottom of page')).toBeInViewport()
+  const originalBox = await page.locator('#gl').boundingBox()
+
+  if (originalBox === null) {
+    throw new Error('boundingBox is null, meaning canvas is not visible')
+  }
+
+  // gradually decrease window size by 100, which triggers nv.resizeListener()
+  for (let i = 0; i < 100; i++) {
+    await page.setViewportSize({width: 600, height: 600 - i})
+  }
+
+  await expect(page.getByText('bottom of page')).toBeInViewport()
+
+  // gradually increase window size until back to original size.
+  for (let i = 0; i < 100; i++) {
+    await page.setViewportSize({width: 600, height: 500 + i})
+  }
+
+  await expect.poll(async () => {
+    const box = await page.locator('#gl').boundingBox()
+    if (box === null) {
+      throw new Error('boundingBox is null, meaning canvas is not visible')
+    }
+    return box.height
+  }).toBe(originalBox.height)
+})

--- a/playwright/e2e/test.niivue.flexboxResize.spec.ts
+++ b/playwright/e2e/test.niivue.flexboxResize.spec.ts
@@ -9,21 +9,18 @@ import { httpServerAddressFlexbox } from './helpers'
 test.beforeEach(async ({ page }) => {
   await page.setViewportSize({ width: 600, height: 600 })
   await page.goto(httpServerAddressFlexbox)
-})
 
-test('canvas size is sized consistently in a flexbox parent', async ({ page }) => {
-  const gl = await page.evaluate(async (testOptions) => {
-    const nv = new Niivue(testOptions)
+  const gl = await page.evaluate(async () => {
+    const nv = new Niivue()
     await nv.attachTo('gl', false)
     return nv.gl
   })
   expect(gl).toBeDefined()
-
-  await page.evaluate(async () => {
-    const nv = new Niivue()
-    await nv.attachTo('gl', false)
-  })
   await expect(page.getByText('bottom of page')).toBeInViewport()
+})
+
+// skipped because I don't have a solution for this atm.
+test.skip('canvas height decreases when viewport height decreases', async ({ page }) => {
   const originalBox = await page.locator('#gl').boundingBox()
 
   if (originalBox === null) {
@@ -51,4 +48,35 @@ test('canvas size is sized consistently in a flexbox parent', async ({ page }) =
       return box.height
     })
     .toBe(originalBox.height)
+})
+
+test('canvas height increases by *close to the* same amount as viewport when viewport is enlarged', async ({
+  page
+}) => {
+  await expect(page.getByText('bottom of page')).toBeInViewport()
+  const originalBox = await page.locator('#gl').boundingBox()
+
+  if (originalBox === null) {
+    throw new Error('boundingBox is null, meaning canvas is not visible')
+  }
+
+  // gradually increase window size by 100, which triggers nv.resizeListener()
+  for (let i = 1; i <= 100; i++) {
+    await page.setViewportSize({ width: 600, height: 600 + i })
+  }
+
+  await expect(page.getByText('bottom of page')).toBeInViewport()
+
+  await expect
+    .poll(async () => {
+      const box = await page.locator('#gl').boundingBox()
+      if (box === null) {
+        throw new Error('boundingBox is null, meaning canvas is not visible')
+      }
+      const expected = originalBox.height + 100
+      const actual = box.height
+      const percentChange = Math.abs(expected - actual) / expected
+      return percentChange
+    })
+    .toBeLessThan(0.05)
 })

--- a/playwright/e2e/test.niivue.flexboxResize.spec.ts
+++ b/playwright/e2e/test.niivue.flexboxResize.spec.ts
@@ -31,22 +31,24 @@ test('canvas size is sized consistently in a flexbox parent', async ({ page }) =
   }
 
   // gradually decrease window size by 100, which triggers nv.resizeListener()
-  for (let i = 0; i < 100; i++) {
-    await page.setViewportSize({width: 600, height: 600 - i})
+  for (let i = 1; i <= 100; i++) {
+    await page.setViewportSize({ width: 600, height: 600 - i })
   }
 
   await expect(page.getByText('bottom of page')).toBeInViewport()
 
   // gradually increase window size until back to original size.
-  for (let i = 0; i < 100; i++) {
-    await page.setViewportSize({width: 600, height: 500 + i})
+  for (let i = 1; i <= 100; i++) {
+    await page.setViewportSize({ width: 600, height: 500 + i })
   }
 
-  await expect.poll(async () => {
-    const box = await page.locator('#gl').boundingBox()
-    if (box === null) {
-      throw new Error('boundingBox is null, meaning canvas is not visible')
-    }
-    return box.height
-  }).toBe(originalBox.height)
+  await expect
+    .poll(async () => {
+      const box = await page.locator('#gl').boundingBox()
+      if (box === null) {
+        throw new Error('boundingBox is null, meaning canvas is not visible')
+      }
+      return box.height
+    })
+    .toBe(originalBox.height)
 })

--- a/src/niivue/index.ts
+++ b/src/niivue/index.ts
@@ -971,6 +971,7 @@ export class Niivue {
     if (this.opts.isResizeCanvas) {
       this.canvas.style.width = '100%'
       this.canvas.style.height = '100%'
+      this.canvas.style.display = 'block'
       this.canvas.width = this.canvas.offsetWidth
       this.canvas.height = this.canvas.offsetHeight
       window.addEventListener('resize', this.resizeListener.bind(this)) // must bind 'this' niivue object or else 'this' becomes 'window'
@@ -1093,6 +1094,8 @@ export class Niivue {
     }
     this.canvas.style.width = '100%'
     this.canvas.style.height = '100%'
+    this.canvas.style.display = 'block'
+
     // https://webglfundamentals.org/webgl/lessons/webgl-resizing-the-canvas.html
     // https://www.khronos.org/webgl/wiki/HandlingHighDPI
     if (this.opts.isHighResolutionCapable) {

--- a/tests/flexbox.html
+++ b/tests/flexbox.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <title>niivue flexbox test</title>
+
+    <style>
+      html, body, main {
+        height: 100%;
+        width: 100%;
+      }
+
+      main {
+        display: flex;
+        flex-direction: column;
+      }
+
+      #niivue-container {
+        height: 100%;
+        width: 100%;
+      }
+
+      .text-block {
+        height: 100px;
+        overflow: hidden;
+      }
+
+
+    </style>
+  </head>
+  <body>
+
+  <main>
+    <div class="text-block">
+      <h1>top of page</h1>
+    </div>
+    <div id="niivue-container">
+      <canvas id="gl"></canvas>
+    </div>
+
+    <div class="text-block">
+      <h1>bottom of page</h1>
+    </div>
+
+  </main>
+    <script type="module">
+      import * as niivue from '../dist/index.js'
+      globalThis.Niivue = niivue.Niivue
+      globalThis.niivue = niivue
+    </script>
+  </body>
+</html>

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -27,6 +27,7 @@ function ensureDownloadFolder() {
 
 module.exports.httpServerAddress = 'http://localhost:8888/tests/index.html'
 module.exports.httpServerAddressSync = 'http://localhost:8888/tests/sync.html'
+module.exports.httpServerAddressFlexbox = 'http://localhost:8888/tests/flexbox.html'
 module.exports.httpServerAddressDemos = 'http://localhost:8888/demos/features/'
 module.exports.snapshot = snapshot
 module.exports.seconds = seconds


### PR DESCRIPTION
Fixes #862, but not perfectly.

## Previous behavior

When viewport height is gradually increased, the canvas' height increases at 4x the rate of change

https://github.com/niivue/niivue/assets/20404439/a77cc287-bb78-4ece-af51-e2234bf5a211

When viewport height is gradually decreased, the canvas' height increases at 3x the rate of change

https://github.com/niivue/niivue/assets/20404439/14498b5d-f8c6-47c4-956a-1e586f1802a3

## New behavior

- When viewport height is gradually increased, the canvas' height increases at 0.99x the rate of change (visually correct behavior)
- When viewport height is gradually decreased, the canvas' height is at first unchanged, then decreases (incorrect behavior, however it is nonetheless a preferable outcome)

https://github.com/niivue/niivue/assets/20404439/66f6b6a0-d5ab-4fe2-bcbc-edb12836fe0b

## Additions to the code

- `display: block` is set on the `canvas` element, which fixes a sizing problem when the canvas has `height: 100%` and is a child of a `display: flex`
- added a regression test to check that the `canvas` element's height increases by approximately the same amount as the viewport's change in height when the viewport's height is gradually increased.
- added a regression test to check that the `canvas` element's height is resized appropriately when the viewport's height is gradually decreased and then increased. However, this test is skipped because I don't know how to fix the bug.
