### PR TITLE
Fix setCrosshairWidth when this.crosshairs3D is null

### DIFF
--- a/playwright/e2e/test.niivue.setCrosshairWidth.spec.js
+++ b/playwright/e2e/test.niivue.setCrosshairWidth.spec.js
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test'
+import { httpServerAddress } from './helpers'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(httpServerAddress)
+})
+
+test('niivue crosshairWidth can be set', async ({ page }) => {
+  const errors = []
+  page.on('pageerror', (error) => errors.push(error))
+  const opts = await page.evaluate(async () => {
+    // eslint-disable-next-line no-undef
+    const nv = new Niivue()
+    nv.setCrosshairWidth(3)
+    await nv.attachTo('gl', false)
+    return nv.opts
+  })
+  expect(opts.crosshairWidth).toEqual(3)
+  expect(errors).toHaveLength(0)
+})

--- a/src/niivue/index.ts
+++ b/src/niivue/index.ts
@@ -3124,7 +3124,9 @@ export class Niivue {
    */
   setCrosshairWidth(crosshairWidth: number): void {
     this.opts.crosshairWidth = crosshairWidth
-    this.crosshairs3D!.mm![0] = NaN // force redraw
+    if (this.crosshairs3D) {
+      this.crosshairs3D.mm![0] = NaN // force redraw
+    }
     this.drawScene()
   }
 


### PR DESCRIPTION
Fixed a bug and added a regression test. Previously, an error would be raised:

```
TypeError: Cannot read properties of null (reading 'mm')
```