### PR TITLE
Fix canvas parent resizing issue

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -57,7 +57,7 @@
       />
       <button id="about">About</button>
     </header>
-    <main>
+    <main id="canvas-container">
       <canvas id="gl1"></canvas>
     </main>
     <footer>
@@ -118,6 +118,17 @@
         };
         cmapEl.appendChild(btn);
       }
+      // TEMPORARY! TODO: remove before merging into main
+      // every 500ms make the canvas container 2px shorter and narrower
+      let resizeInterval = setInterval(() => {
+        let canvasContainer = document.getElementById("canvas-container");
+        canvasContainer.style.width = canvasContainer.offsetWidth - 2 + "px";
+        canvasContainer.style.height = canvasContainer.offsetHeight - 2 + "px";
+        // stop when the canvas container is 500px wide
+        if (canvasContainer.offsetWidth <= 500) {
+          clearInterval( resizeInterval);
+        }
+      }, 16);
     </script>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -118,17 +118,6 @@
         };
         cmapEl.appendChild(btn);
       }
-      // TEMPORARY! TODO: remove before merging into main
-      // every 500ms make the canvas container 2px shorter and narrower
-      let resizeInterval = setInterval(() => {
-        let canvasContainer = document.getElementById("canvas-container");
-        canvasContainer.style.width = canvasContainer.offsetWidth - 2 + "px";
-        canvasContainer.style.height = canvasContainer.offsetHeight - 2 + "px";
-        // stop when the canvas container is 500px wide
-        if (canvasContainer.offsetWidth <= 500) {
-          clearInterval( resizeInterval);
-        }
-      }, 16);
     </script>
   </body>
 </html>

--- a/src/niivue/index.ts
+++ b/src/niivue/index.ts
@@ -449,10 +449,10 @@ export class Niivue {
   overlayAlphaShader = 1 // float, 1 for opaque
   isAlphaClipDark = false
   position?: vec3
-
   extentsMin?: vec3
   extentsMax?: vec3
-
+  // ResizeObserver
+  private resizeObserver: ResizeObserver | null = null
   syncOpts: Record<string, unknown> = {}
   readyForSync = false
 
@@ -989,6 +989,8 @@ export class Niivue {
       this.canvas.width = this.canvas.offsetWidth
       this.canvas.height = this.canvas.offsetHeight
       window.addEventListener('resize', this.resizeListener.bind(this)) // must bind 'this' niivue object or else 'this' becomes 'window'
+      this.resizeObserver = new ResizeObserver(this.resizeListener.bind(this))
+      this.resizeObserver.observe(this.canvas.parentElement!)
     }
     this.registerInteractions() // attach mouse click and touch screen event handlers for the canvas
     await this.init()


### PR DESCRIPTION
- closes #861 

@jennydaman , please checkout the `bug-isresizecanvas` branch and then run `npm run dev`. The example web page that loads should automatically resize the parent element of the canvas, and trigger a proper redrawing of the canvas. 

So, now niivue will be aware of window resize events AND the resize events of the `canvas` parent element. This implementation uses the `ResizeObserver` which should be available in all major browsers. 

@jennydaman , you should be able to remove your [workaround](https://github.com/jennydaman/ChRIS_ui/commit/8b1e3ac96629967712e6370e074d897f0b8f32b0) once this is published in a new version of Niivue. 
