### PR TITLE
Fix getFrame4D method to use correct property

### DIFF
--- a/src/niivue/index.ts
+++ b/src/niivue/index.ts
@@ -6025,7 +6025,7 @@ export class Niivue {
    */
   getFrame4D(id: string): number {
     const idx = this.getVolumeIndexByID(id)
-    return this.volumes[idx].nFrame4D!
+    return this.volumes[idx].frame4D!
   }
 
   // not included in public docs


### PR DESCRIPTION
List of fixed issues (if they exist):

- closes #902 

`getFrame4D` was using the `nFrame4D` property which is wrong. `nFrame4D` was intended to represent the max number of volumes. 

Upon investigation, I discovered that we use both `nFrame4D` and `nTotalFrame4D` which seems redundant. 

@neurolabusc , are you in favour of removing the `nTotalFrame4D` property from `NVImage`? I can do so if you agree. 