### PR TITLE
run correct build command for online demos

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install and Build
         run: |
           npm install
-          npm run build
+          npm run build:forTests
           npm run docs
           cp -r dist demos/dist
           cp -r devdocs demos/


### PR DESCRIPTION
This PR fixes the broken live demos due to a build script change. 
