### PR TITLE
only allow idModulation to be a string

### DIFF
--- a/demos/features/modulate.html
+++ b/demos/features/modulate.html
@@ -112,7 +112,7 @@
         }
         if ((mode === 4) || (mode === 2)) {
           nv1.setModulationImage(nv1.volumes[1].id,nv1.volumes[0].id);
-        } else nv1.setModulationImage(nv1.volumes[1].id, null);
+        } else nv1.setModulationImage(nv1.volumes[1].id, '');
         nv1.opts.isV1SliceShader = (mode > 2);
         nv1.updateGLVolume()
       };

--- a/demos/features/modulateAfni.html
+++ b/demos/features/modulateAfni.html
@@ -134,7 +134,7 @@
             nv1.volumes[1].id,
             modulateAlpha
           )
-        } else nv1.setModulationImage(nv1.volumes[2].id, null)
+        } else nv1.setModulationImage(nv1.volumes[2].id, '')
       }
       nv1.overlayOutlineWidth = 1
       nv1.volumes[0].colorbarVisible = false //hide colorbar for anatomical scan

--- a/demos/features/modulateScalar.html
+++ b/demos/features/modulateScalar.html
@@ -134,7 +134,7 @@
             nv1.volumes[2].id,
             modulateAlpha
           );
-        } else nv1.setModulationImage(nv1.volumes[1].id, null);
+        } else nv1.setModulationImage(nv1.volumes[1].id, '');
       };
       drop.onchange();
     </script>

--- a/src/niivue/index.ts
+++ b/src/niivue/index.ts
@@ -5909,7 +5909,7 @@ export class Niivue {
   /**
    * modulate intensity of one image based on intensity of another
    * @param idTarget - the ID of the NVImage to be biased
-   * @param idModulation - the ID of the NVImage that controls bias (null to disable modulation)
+   * @param idModulation - the ID of the NVImage that controls bias (empty string to disable modulation)
    * @param modulateAlpha - does the modulation influence alpha transparency (values greater than 1).
    * @example niivue.setModulationImage(niivue.volumes[0].id, niivue.volumes[1].id);
    * @see {@link https://niivue.github.io/niivue/features/modulate.html|live demo scalar usage}
@@ -5919,11 +5919,13 @@ export class Niivue {
     // to set:
     // nv1.setModulationImage(nv1.volumes[0].id, nv1.volumes[1].id);
     // to clear:
-    // nv1.setModulationImage(nv1.volumes[0].id, null);
+    // nv1.setModulationImage(nv1.volumes[0].id, '');
     const idxTarget = this.getVolumeIndexByID(idTarget)
-    let idxModulation = null
-    // if (idModulation)
-    idxModulation = this.getVolumeIndexByID(idModulation)
+    // idxModulation can be null or the index of the modulation image
+    let idxModulation: number | null = null
+    if (idModulation.length > 0) {
+      idxModulation = this.getVolumeIndexByID(idModulation)
+    }
     this.volumes[idxTarget].modulationImage = idxModulation
     this.volumes[idxTarget].modulateAlpha = modulateAlpha
     this.updateGLVolume()


### PR DESCRIPTION
Previously, the `idModulation` argument to `setModulationImage` could accept a string or `null`. I have updated `setModulationImage` to only accept a string (or empty string) rather than both strings and `null`. The demos that use this feature have also been updated. To clear the modulation, a user must supply an empty string as the value for `idModulation`. 

I have checked that the AFNI usage of this feature is not impacted. 

List of fixed issues (if they exist):

- closes #859 

