### PR TITLE
Optimize mesh types

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -99,7 +99,7 @@
       nv1.opts.yoke3Dto2DZoom = true;
       await nv1.loadVolumes(volumeList1);
       var layerList = [{url: "../demos/images/mni152.SLF1_R.tsf"}];
-      await nv1.loadMeshes([{ url: "../demos/images/tract.SLF1_R.tck", layers: layerList,}]);
+      await nv1.loadMeshes([{ url: "../demos/images/tract.SLF1_R.tck", layers: layerList,}, { url: "../demos/images/lh.pial"}]);
       nv1.setMeshProperty(nv1.meshes[0].id, "fiberColor", "DPV0");
       nv1.setMeshProperty(nv1.meshes[0].id, "fiberDither", 0);
       nv1.setMeshProperty(nv1.meshes[0].id, "fiberRadius", 0.5);

--- a/src/index.html
+++ b/src/index.html
@@ -99,7 +99,7 @@
       nv1.opts.yoke3Dto2DZoom = true;
       await nv1.loadVolumes(volumeList1);
       var layerList = [{url: "../demos/images/mni152.SLF1_R.tsf"}];
-      await nv1.loadMeshes([{ url: "../demos/images/tract.SLF1_R.tck", layers: layerList,}, { url: "../demos/images/lh.pial"}]);
+      await nv1.loadMeshes([{ url: "../demos/images/tract.SLF1_R.tck", layers: layerList,}]);
       nv1.setMeshProperty(nv1.meshes[0].id, "fiberColor", "DPV0");
       nv1.setMeshProperty(nv1.meshes[0].id, "fiberDither", 0);
       nv1.setMeshProperty(nv1.meshes[0].id, "fiberRadius", 0.5);

--- a/src/nvconnectome.ts
+++ b/src/nvconnectome.ts
@@ -45,9 +45,7 @@ export class NVConnectome extends NVMesh {
   nodesChanged: EventTarget
 
   constructor(gl: WebGL2RenderingContext, connectome: LegacyConnectome) {
-    super(
-    new Float32Array([]),
-    new Uint32Array([]), connectome.name, new Uint8Array([]), 1.0, true, gl, connectome)
+    super(new Float32Array([]), new Uint32Array([]), connectome.name, new Uint8Array([]), 1.0, true, gl, connectome)
     this.gl = gl
     // this.nodes = connectome.nodes;
     // this.edges = connectome.edges;
@@ -368,16 +366,18 @@ export class NVConnectome extends NVMesh {
       NiivueObject3D.makeColoredCylinder(pts, tris, rgba255, pti, ptj, radius, rgba)
     }
 
+    let pts32 = new Float32Array(pts)
+    let tris32 = new Uint32Array(tris)
     // calculate spatial extent of connectome: user adjusting node sizes may influence size
-    const obj = NVMeshUtilities.getExtents(pts)
+    const obj = NVMeshUtilities.getExtents(pts32)
 
     this.furthestVertexFromOrigin = obj.mxDx
     this.extentsMin = obj.extentsMin
     this.extentsMax = obj.extentsMax
-    const posNormClr = this.generatePosNormClr(pts, tris, new Uint8Array(rgba255))
+    const posNormClr = this.generatePosNormClr(pts32, tris32, new Uint8Array(rgba255))
     // generate webGL buffers and vao
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.indexBuffer)
-    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Int32Array(tris), gl.STATIC_DRAW)
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, tris32, gl.STATIC_DRAW)
     gl.bindBuffer(gl.ARRAY_BUFFER, this.vertexBuffer)
     gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(posNormClr), gl.STATIC_DRAW)
     this.indexCount = tris.length

--- a/src/nvconnectome.ts
+++ b/src/nvconnectome.ts
@@ -45,7 +45,11 @@ export class NVConnectome extends NVMesh {
   nodesChanged: EventTarget
 
   constructor(gl: WebGL2RenderingContext, connectome: LegacyConnectome) {
-    super([], [], connectome.name, [], 1.0, true, gl, connectome)
+    super([], 
+    [], 
+    connectome.name, 
+    new Uint8Array([])
+    , 1.0, true, gl, connectome)
     this.gl = gl
     // this.nodes = connectome.nodes;
     // this.edges = connectome.edges;
@@ -372,7 +376,7 @@ export class NVConnectome extends NVMesh {
     this.furthestVertexFromOrigin = obj.mxDx
     this.extentsMin = obj.extentsMin
     this.extentsMax = obj.extentsMax
-    const posNormClr = this.generatePosNormClr(pts, tris, rgba255)
+    const posNormClr = this.generatePosNormClr(pts, tris, new Uint8Array(rgba255))
     // generate webGL buffers and vao
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.indexBuffer)
     gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Int32Array(tris), gl.STATIC_DRAW)

--- a/src/nvconnectome.ts
+++ b/src/nvconnectome.ts
@@ -45,9 +45,9 @@ export class NVConnectome extends NVMesh {
   nodesChanged: EventTarget
 
   constructor(gl: WebGL2RenderingContext, connectome: LegacyConnectome) {
-    super([],
-    new Uint32Array([]),
-    connectome.name, new Uint8Array([]), 1.0, true, gl, connectome)
+    super(
+    new Float32Array([]),
+    new Uint32Array([]), connectome.name, new Uint8Array([]), 1.0, true, gl, connectome)
     this.gl = gl
     // this.nodes = connectome.nodes;
     // this.edges = connectome.edges;

--- a/src/nvconnectome.ts
+++ b/src/nvconnectome.ts
@@ -45,7 +45,9 @@ export class NVConnectome extends NVMesh {
   nodesChanged: EventTarget
 
   constructor(gl: WebGL2RenderingContext, connectome: LegacyConnectome) {
-    super([], [], connectome.name, new Uint8Array([]), 1.0, true, gl, connectome)
+    super([],
+    new Uint32Array([]),
+    connectome.name, new Uint8Array([]), 1.0, true, gl, connectome)
     this.gl = gl
     // this.nodes = connectome.nodes;
     // this.edges = connectome.edges;

--- a/src/nvconnectome.ts
+++ b/src/nvconnectome.ts
@@ -377,9 +377,9 @@ export class NVConnectome extends NVMesh {
     const posNormClr = this.generatePosNormClr(pts32, tris32, new Uint8Array(rgba255))
     // generate webGL buffers and vao
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.indexBuffer)
-    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, tris32, gl.STATIC_DRAW)
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, Uint32Array.from(tris32), gl.STATIC_DRAW)
     gl.bindBuffer(gl.ARRAY_BUFFER, this.vertexBuffer)
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(posNormClr), gl.STATIC_DRAW)
+    gl.bufferData(gl.ARRAY_BUFFER, Float32Array.from(posNormClr), gl.STATIC_DRAW)
     this.indexCount = tris.length
   }
 

--- a/src/nvconnectome.ts
+++ b/src/nvconnectome.ts
@@ -366,8 +366,8 @@ export class NVConnectome extends NVMesh {
       NiivueObject3D.makeColoredCylinder(pts, tris, rgba255, pti, ptj, radius, rgba)
     }
 
-    let pts32 = new Float32Array(pts)
-    let tris32 = new Uint32Array(tris)
+    const pts32 = new Float32Array(pts)
+    const tris32 = new Uint32Array(tris)
     // calculate spatial extent of connectome: user adjusting node sizes may influence size
     const obj = NVMeshUtilities.getExtents(pts32)
 

--- a/src/nvconnectome.ts
+++ b/src/nvconnectome.ts
@@ -45,11 +45,7 @@ export class NVConnectome extends NVMesh {
   nodesChanged: EventTarget
 
   constructor(gl: WebGL2RenderingContext, connectome: LegacyConnectome) {
-    super([], 
-    [], 
-    connectome.name, 
-    new Uint8Array([])
-    , 1.0, true, gl, connectome)
+    super([], [], connectome.name, new Uint8Array([]), 1.0, true, gl, connectome)
     this.gl = gl
     // this.nodes = connectome.nodes;
     // this.edges = connectome.edges;

--- a/src/nvdocument.ts
+++ b/src/nvdocument.ts
@@ -616,7 +616,7 @@ export class NVDocument {
         pts: mesh.pts,
         tris: mesh.tris,
         name: mesh.name,
-        rgba255: mesh.rgba255,
+        rgba255: Uint8Array.from(mesh.rgba255),
         opacity: mesh.opacity,
         connectome: mesh.connectome,
         dpg: mesh.dpg,

--- a/src/nvmesh-loaders.ts
+++ b/src/nvmesh-loaders.ts
@@ -916,7 +916,7 @@ export class NVMeshLoaders {
     } else {
       throw new Error('Unsupported ASCII VTK datatype ' + items[0])
     }
-    const indices = new Int32Array(tris)
+    const indices = new Uint32Array(tris)
     return {
       positions,
       indices
@@ -1397,7 +1397,7 @@ export class NVMeshLoaders {
     let v = 0
     let t = 0
     let positions: Float32Array
-    let indices: Int32Array
+    let indices: Uint32Array
     while (pos < len) {
       const line = readStr()
       if (line.startsWith('#')) {
@@ -1418,7 +1418,7 @@ export class NVMeshLoaders {
       }
       if (ntri < 1) {
         ntri = parseInt(items[0])
-        indices = new Int32Array(ntri * 3)
+        indices = new Uint32Array(ntri * 3)
         continue
       }
       if (t >= ntri * 3) {
@@ -1474,7 +1474,7 @@ export class NVMeshLoaders {
       positions[j + 2] = parseFloat(items[2])
       j += 3
     }
-    const indices = new Int32Array(ntri * 3)
+    const indices = new Uint32Array(ntri * 3)
     j = 0
     for (let i = 0; i < ntri; i++) {
       line = readStr() // 1st line: signature
@@ -1658,7 +1658,7 @@ export class NVMeshLoaders {
     } else {
       throw new Error('Unsupported binary VTK datatype ' + items[0])
     }
-    const indices = new Int32Array(tris)
+    const indices = new Uint32Array(tris)
     return {
       positions,
       indices
@@ -1688,7 +1688,7 @@ export class NVMeshLoaders {
     // var precision = reader.getUint32(52, true);
     // float64 orientation[4][4]; //4x4 matrix, affine transformation to world coordinates*)
     let pos = hdrBytes
-    const indices = new Int32Array(buffer, pos, nface * 3)
+    const indices = new Uint32Array(buffer, pos, nface * 3)
     pos += nface * 3 * 4
     const positions = new Float32Array(buffer, pos, nvert * 3)
     // oops, triangle winding opposite of CCW convention
@@ -1780,7 +1780,7 @@ export class NVMeshLoaders {
     let filepos = 16 + nskip
     let indices = null
     if (isFace) {
-      indices = new Int32Array(_buffer, filepos, nface * 3)
+      indices = new Uint32Array(_buffer, filepos, nface * 3)
       filepos += nface * 3 * 4
     }
     let positions = null
@@ -1946,7 +1946,7 @@ export class NVMeshLoaders {
         positions[v + 2] = parseFloat(items[2])
         v += 3
       }
-      let indices = new Int32Array(nface * 3)
+      let indices = new Uint32Array(nface * 3)
       let f = 0
       for (let i = 0; i < nface; i++) {
         line = readStr()
@@ -1956,7 +1956,7 @@ export class NVMeshLoaders {
           break
         } // error
         if (f + nTri * 3 > indices.length) {
-          const c = new Int32Array(indices.length + indices.length)
+          const c = new Uint32Array(indices.length + indices.length)
           c.set(indices)
           indices = c.slice()
         }
@@ -2008,7 +2008,7 @@ export class NVMeshLoaders {
         pos += vertStride
       }
     }
-    const indices = new Int32Array(nface * 3) // assume triangular mesh: pre-allocation optimization
+    const indices = new Uint32Array(nface * 3) // assume triangular mesh: pre-allocation optimization
     let isTriangular = true
     let j = 0
     if (indexCountBytes === 1 && indexBytes === 4 && indexStrideBytes === 13) {
@@ -2108,7 +2108,7 @@ export class NVMeshLoaders {
     header = lines[line].trim().split(/\s+/)
     line++
     const num_f = parseInt(header[0])
-    const indices = new Int32Array(num_f * 3)
+    const indices = new Uint32Array(num_f * 3)
     for (let i = 0; i < num_f; i++) {
       const items = lines[line].trim().split(/\s+/)
       line++
@@ -2202,7 +2202,7 @@ export class NVMeshLoaders {
     }
     // return results
     const positions = new Float32Array(pts)
-    const indices = new Int32Array(t)
+    const indices = new Uint32Array(t)
     return {
       positions,
       indices
@@ -2250,7 +2250,7 @@ export class NVMeshLoaders {
       i++
     }
     const positions = new Float32Array(pts)
-    const indices = new Int32Array(t)
+    const indices = new Uint32Array(t)
     return {
       positions,
       indices
@@ -2292,7 +2292,7 @@ export class NVMeshLoaders {
     j += num_c * 4
     j += nTri
     const nTriX3 = nTri * 3
-    const indices = new Int32Array(nTriX3)
+    const indices = new Uint32Array(nTriX3)
     for (let i = 0; i < nTriX3; i++) {
       indices[i] = parseInt(items[j++])
     }
@@ -2344,7 +2344,7 @@ export class NVMeshLoaders {
       }
     } // for all lines
     const positions = new Float32Array(pts)
-    const indices = new Int32Array(t)
+    const indices = new Uint32Array(t)
     return {
       positions,
       indices
@@ -2379,7 +2379,7 @@ export class NVMeshLoaders {
       offset += 4
     }
     nf *= 3 // each triangle face indexes 3 triangles
-    const indices = new Int32Array(nf)
+    const indices = new Uint32Array(nf)
     for (let i = 0; i < nf; i++) {
       indices[i] = view.getUint32(offset, false)
       offset += 4
@@ -2511,7 +2511,7 @@ export class NVMeshLoaders {
       const nNearest = reader.getUint32(pos, true)
       pos += 4 + 4 * nNearest
     }
-    const indices = new Int32Array(nTri * 3)
+    const indices = new Uint32Array(nTri * 3)
     for (let i = 0; i < nTri * 3; i++) {
       indices[i] = reader.getInt32(pos, true)
       pos += 4
@@ -2551,7 +2551,7 @@ export class NVMeshLoaders {
       throw new Error('Unable to parse ASCII STL file.')
     }
     const positions = new Float32Array(pts)
-    const indices = new Int32Array(npts)
+    const indices = new Uint32Array(npts)
     for (let i = 0; i < npts; i++) {
       indices[i] = i
     }
@@ -2577,7 +2577,7 @@ export class NVMeshLoaders {
     if (buffer.byteLength < 80 + 4 + ntri * 50) {
       throw new Error('STL file too small to store triangles = ' + ntri)
     }
-    const indices = new Int32Array(ntri3)
+    const indices = new Uint32Array(ntri3)
     const positions = new Float32Array(ntri3 * 3)
     let pos = 80 + 4 + 12
     let v = 0 // vertex
@@ -2641,7 +2641,7 @@ export class NVMeshLoaders {
       let indexCount = 0
       let surfaceNumberOfVertices = 0
       let brainStructure = ''
-      let vertexIndices: Int32Array = new Int32Array()
+      let vertexIndices: Uint32Array = new Uint32Array()
       const bytes = new Uint8Array(buffer)
       let pos = 552
 
@@ -2739,7 +2739,7 @@ export class NVMeshLoaders {
           if (items.length < indexCount) {
             log.error('Error parsing VertexIndices')
           }
-          vertexIndices = new Int32Array(indexCount)
+          vertexIndices = new Uint32Array(indexCount)
           for (let i = 0; i < indexCount; i++) {
             vertexIndices[i] = parseInt(items[i])
           }
@@ -3329,7 +3329,7 @@ export class NVMeshLoaders {
     }
     return {
       positions: Float32Array.from(positions),
-      indices: Int32Array.from(indices),
+      indices: Uint32Array.from(indices),
       rgba255: Uint8Array.from(rgba255)
     }
   } // readX3D()
@@ -3410,7 +3410,7 @@ export class NVMeshLoaders {
     }
     len = tag.contentEndPos // only read contents of GIfTI tag
     let positions = new Float32Array()
-    let indices = new Int32Array()
+    let indices = new Uint32Array()
     let scalars = new Float32Array()
     let anatomicalStructurePrimary = ''
     let isIdx = false
@@ -3545,7 +3545,7 @@ export class NVMeshLoaders {
           if (dataType !== 8) {
             log.warn('expect indices as INT32')
           }
-          indices = new Int32Array(datBin!.buffer)
+          indices = new Uint32Array(datBin!.buffer)
           if (isColMajor) {
             const tmp = indices.slice()
             const np = tmp.length / 3

--- a/src/nvmesh-loaders.ts
+++ b/src/nvmesh-loaders.ts
@@ -205,7 +205,7 @@ export class NVMeshLoaders {
       return mat
     } // readMatV4()
     let offsetPt0: AnyNumberArray = []
-    let pts: AnyNumberArray = []
+    let pts = new Float32Array(0)
     const mat = readMatV4(buffer)
     if (!('trans_to_mni' in mat)) {
       throw new Error("TT format file must have 'trans_to_mni'")
@@ -316,7 +316,7 @@ export class NVMeshLoaders {
     } // decodeFloat16()
     let noff = 0
     let npt = 0
-    let pts: number[] = []
+    let pts = new Float32Array([])
     const offsetPt0: number[] = []
     const dpg = []
     const dps = []
@@ -440,7 +440,7 @@ export class NVMeshLoaders {
       }
       if (fname.startsWith('positions.3.')) {
         npt = nval // 4 bytes per 32bit input
-        pts = Array.from(vals.slice())
+        pts = new Float32Array(vals)
       }
     }
     if (noff === 0 || npt === 0) {
@@ -452,7 +452,7 @@ export class NVMeshLoaders {
     }
     offsetPt0[noff] = npt / 3 // solve fence post problem, offset for final streamline
     return {
-      pts: Array.from(pts),
+      pts,
       offsetPt0: Array.from(offsetPt0),
       dpg,
       dps,

--- a/src/nvmesh-loaders.ts
+++ b/src/nvmesh-loaders.ts
@@ -105,7 +105,7 @@ export class NVMeshLoaders {
       line = readStr() // </tracts>
     }
     return {
-      pts,
+      pts: new Float32Array(pts),
       offsetPt0,
       dps
     }
@@ -204,7 +204,7 @@ export class NVMeshLoaders {
       }
       return mat
     } // readMatV4()
-    let offsetPt0: AnyNumberArray = []
+    let offsetPt0 = new Uint32Array(0)
     let pts = new Float32Array(0)
     const mat = readMatV4(buffer)
     if (!('trans_to_mni' in mat)) {
@@ -453,7 +453,7 @@ export class NVMeshLoaders {
     offsetPt0[noff] = npt / 3 // solve fence post problem, offset for final streamline
     return {
       pts,
-      offsetPt0: Array.from(offsetPt0),
+      offsetPt0: new Uint32Array(offsetPt0),
       dpg,
       dps,
       dpv,

--- a/src/nvmesh-loaders.ts
+++ b/src/nvmesh-loaders.ts
@@ -105,7 +105,7 @@ export class NVMeshLoaders {
       id: 'tract',
       vals: Float32Array.from(bundleTags)
     })
-    
+
     return {
       pts: new Float32Array(pts),
       offsetPt0: new Uint32Array(offsetPt0),
@@ -409,7 +409,7 @@ export class NVMeshLoaders {
       if (pname.includes('dpv')) {
         dpv.push({
           id: tag,
-          vals: Float32Array.from(vals.slice()),
+          vals: Float32Array.from(vals.slice())
         })
         continue
       }
@@ -629,7 +629,7 @@ export class NVMeshLoaders {
       const str = new TextDecoder().decode(arr).split('\0').shift()
       dpv.push({
         id: str!.trim(), // TODO can we guarantee this?
-        vals: [] as number[],
+        vals: [] as number[]
       })
     }
     const voxel_sizeX = reader.getFloat32(12, true)
@@ -719,7 +719,7 @@ export class NVMeshLoaders {
         }
       }
     } // for each streamline: while i < n_count
-    //output uses static float32 not dynamic number[]
+    // output uses static float32 not dynamic number[]
     const dps32 = []
     // data_per_streamline
     for (let i = 0; i < dps.length; i++) {
@@ -730,10 +730,10 @@ export class NVMeshLoaders {
     }
     const dpv32 = []
     for (let s = 0; s < dpv.length; s++) {
-        dpv32.push({
-          id: dpv[i].id,
-          vals: Float32Array.from(dpv[i].vals)
-        })
+      dpv32.push({
+        id: dpv[i].id,
+        vals: Float32Array.from(dpv[i].vals)
+      })
     }
     // add 'first index' as if one more line was added (fence post problem)
     offsetPt0[noffset++] = npt

--- a/src/nvmesh-loaders.ts
+++ b/src/nvmesh-loaders.ts
@@ -3330,7 +3330,7 @@ export class NVMeshLoaders {
     return {
       positions: Float32Array.from(positions),
       indices: Int32Array.from(indices),
-      rgba255
+      rgba255: Uint8Array.from(rgba255)
     }
   } // readX3D()
 

--- a/src/nvmesh-loaders.ts
+++ b/src/nvmesh-loaders.ts
@@ -106,7 +106,7 @@ export class NVMeshLoaders {
     }
     return {
       pts: new Float32Array(pts),
-      offsetPt0,
+      offsetPt0: new Uint32Array(offsetPt0),
       dps
     }
   } // readTRACT()

--- a/src/nvmesh-types.ts
+++ b/src/nvmesh-types.ts
@@ -3,7 +3,7 @@ import { LUT } from './colortables.js'
 
 export type ValuesArray = Array<{
   id: string
-  vals: number[]
+  vals: Float32Array
   global_min?: number
   global_max?: number
   cal_min?: number

--- a/src/nvmesh-types.ts
+++ b/src/nvmesh-types.ts
@@ -24,7 +24,7 @@ export type AnyNumberArray = number[] | TypedNumberArray
 
 export type DefaultMeshType = {
   positions: Float32Array
-  indices: Int32Array
+  indices: Uint32Array
   colors?: Float32Array
 }
 
@@ -78,7 +78,7 @@ export type MZ3 =
   | Float32Array
   | {
       positions: Float32Array | null
-      indices: Int32Array | null
+      indices: Uint32Array | null
       scalars: Float32Array
       colors: Float32Array | null
     }
@@ -86,7 +86,7 @@ export type MZ3 =
 export type GII = {
   scalars: Float32Array
   positions?: Float32Array
-  indices?: Int32Array
+  indices?: Uint32Array
   colormapLabel?: LUT
   anatomicalStructurePrimary: string
 }
@@ -100,7 +100,7 @@ export type MGH =
 
 export type X3D = {
   positions: Float32Array
-  indices: Int32Array
+  indices: Uint32Array
   rgba255: Uint8Array
 }
 

--- a/src/nvmesh-types.ts
+++ b/src/nvmesh-types.ts
@@ -35,12 +35,12 @@ export type TRACT = {
 }
 
 export type TT = {
-  pts: number[]
+  pts: Float32Array
   offsetPt0: number[]
 }
 
 export type TRX = {
-  pts: number[]
+  pts: Float32Array
   offsetPt0: number[]
   dpg: ValuesArray
   dps: ValuesArray

--- a/src/nvmesh-types.ts
+++ b/src/nvmesh-types.ts
@@ -30,7 +30,7 @@ export type DefaultMeshType = {
 
 export type TRACT = {
   pts: Float32Array
-  offsetPt0: number[]
+  offsetPt0: Uint32Array
   dps: ValuesArray
 }
 

--- a/src/nvmesh-types.ts
+++ b/src/nvmesh-types.ts
@@ -101,7 +101,7 @@ export type MGH =
 export type X3D = {
   positions: Float32Array
   indices: Int32Array
-  rgba255: number[]
+  rgba255: Uint8Array
 }
 
 export type Layer = {

--- a/src/nvmesh-types.ts
+++ b/src/nvmesh-types.ts
@@ -29,19 +29,19 @@ export type DefaultMeshType = {
 }
 
 export type TRACT = {
-  pts: number[]
+  pts: Float32Array
   offsetPt0: number[]
   dps: ValuesArray
 }
 
 export type TT = {
   pts: Float32Array
-  offsetPt0: number[]
+  offsetPt0: Uint32Array
 }
 
 export type TRX = {
   pts: Float32Array
-  offsetPt0: number[]
+  offsetPt0: Uint32Array
   dpg: ValuesArray
   dps: ValuesArray
   dpv: ValuesArray

--- a/src/nvmesh.ts
+++ b/src/nvmesh.ts
@@ -1205,7 +1205,7 @@ export class NVMesh {
         obj = NVMeshLoaders.readTRK(buffer)
       }
       if (typeof obj === 'undefined') {
-        const pts = [0, 0, 0, 0, 0, 0]
+        const pts = new Float32Array([0, 0, 0, 0, 0, 0])
         const offsetPt0 = [0]
         obj = { pts, offsetPt0 }
         log.error('Creating empty tracts')
@@ -1690,7 +1690,7 @@ export class NVMesh {
   }
 
   static readTT(buffer: ArrayBuffer): TT {
-    return NVMeshLoaders.readTRX(buffer)
+    return NVMeshLoaders.readTT(buffer)
   }
 
   static readTRX(buffer: ArrayBuffer): TRX {

--- a/src/nvmesh.ts
+++ b/src/nvmesh.ts
@@ -153,7 +153,7 @@ export class NVMesh {
   data_type?: string
   rgba255: number[]
   fiberLength?: number
-  fiberLengths?: number[]
+  fiberLengths?: Uint32Array
   fiberDither = 0.1
   fiberColor = 'Global'
   fiberDecimationStride = 1 // e.g. if 2 the 50% of streamlines visible, if 3 then 1/3rd
@@ -487,7 +487,7 @@ export class NVMesh {
     const npt = pts.length / 3 // each point has three components: X,Y,Z
     // only once: compute length of each streamline
     if (!this.fiberLengths) {
-      this.fiberLengths = []
+      this.fiberLengths = new Uint32Array(n_count)
       for (let i = 0; i < n_count; i++) {
         // for each streamline
         const vStart3 = offsetPt0[i] * 3 // first vertex in streamline
@@ -497,7 +497,7 @@ export class NVMesh {
           const v = vec3.fromValues(pts[j + 0] - pts[j + 3], pts[j + 1] - pts[j + 4], pts[j + 2] - pts[j + 5])
           len += vec3.len(v)
         }
-        this.fiberLengths.push(len)
+        this.fiberLengths[i] = len
       }
     } // only once: compute length of each streamline
     // determine fiber colors

--- a/src/nvmesh.ts
+++ b/src/nvmesh.ts
@@ -1191,7 +1191,7 @@ export class NVMesh {
       // return NVMesh.loadConnectomeFromFreeSurfer(JSON.parse(new TextDecoder().decode(buffer)), gl, name, opacity)
       log.error('you should never see this message: load using nvconnectome not nvmesh')
     }
-    rgba255[3] = Math.max(0, rgba255[3])
+    rgba255[3] = Math.max(1, rgba255[3])
     if (ext === 'TCK' || ext === 'TRK' || ext === 'TT' || ext === 'TRX' || ext === 'TRACT') {
       if (ext === 'TCK') {
         obj = NVMeshLoaders.readTCK(buffer)
@@ -1210,8 +1210,7 @@ export class NVMesh {
         obj = { pts, offsetPt0 }
         log.error('Creating empty tracts')
       }
-
-      rgba255[3] = -1.0
+      rgba255[3] = 0.0
       return new NVMesh(
         obj.pts,
         obj.offsetPt0,
@@ -1295,7 +1294,7 @@ export class NVMesh {
 
     if ('rgba255' in obj && obj.rgba255.length > 0) {
       // e.g. x3D format
-      //rgba255 = Array.from(obj.rgba255)
+      // rgba255 = Array.from(obj.rgba255)
       rgba255 = obj.rgba255
     }
     if ('colors' in obj && obj.colors && obj.colors.length === pts.length) {
@@ -1311,7 +1310,6 @@ export class NVMesh {
         rgba255[k++] = 255 // alpha
         c += 3
       } // for i: each vertex
-      
     } // obj includes colors
     const npt = pts.length / 3
     const ntri = tris.length / 3

--- a/src/nvmesh.ts
+++ b/src/nvmesh.ts
@@ -64,7 +64,7 @@ export class NVMeshFromUrlOptions {
   gl: WebGL2RenderingContext | null
   name: string
   opacity: number
-  rgba255: number[]
+  rgba255: Uint8Array
   visible: boolean
   layers: NVMeshLayer[]
   colorbarVisible: boolean
@@ -74,7 +74,7 @@ export class NVMeshFromUrlOptions {
     gl = null,
     name = '',
     opacity = 1.0,
-    rgba255 = [255, 255, 255, 255],
+    rgba255 = new Uint8Array([255, 255, 255, 255]),
     visible = true,
     layers = [],
     colorbarVisible = true
@@ -98,7 +98,7 @@ type BaseLoadParams = {
   // the opacity for this image. default is 1
   opacity: number
   // the base color of the mesh. RGBA values from 0 to 255. Default is white
-  rgba255: number[]
+  rgba255: Uint8Array
   // whether or not this image is to be visible
   visible: boolean
   // layers of the mesh to load
@@ -151,7 +151,7 @@ export class NVMesh {
   type = MeshType.MESH
 
   data_type?: string
-  rgba255: number[]
+  rgba255: Uint8Array
   fiberLength?: number
   fiberLengths?: Uint32Array
   fiberDither = 0.1
@@ -209,7 +209,7 @@ export class NVMesh {
     pts: number[] | Float32Array,
     tris: number[] | Uint32Array,
     name = '',
-    rgba255 = [255, 255, 255, 255],
+    rgba255 = new Uint8Array([255, 255, 255, 255]),
     opacity = 1.0,
     visible = true,
     gl: WebGL2RenderingContext,
@@ -1118,7 +1118,7 @@ export class NVMesh {
 
   // Each streamline vertex has color, normal and position attributes
   // Interleaved Vertex Data https://developer.apple.com/library/archive/documentation/3DDrawing/Conceptual/OpenGLES_ProgrammingGuide/TechniquesforWorkingwithVertexData/TechniquesforWorkingwithVertexData.html
-  generatePosNormClr(pts: number[] | Float32Array, tris: number[] | Uint32Array, rgba255: number[]): Float32Array {
+  generatePosNormClr(pts: number[] | Float32Array, tris: number[] | Uint32Array, rgba255: Uint8Array): Float32Array {
     if (pts.length < 3 || rgba255.length < 4) {
       log.error('Catastrophic failure generatePosNormClr()')
       log.debug('this', this)
@@ -1169,7 +1169,7 @@ export class NVMesh {
     name: string,
     gl: WebGL2RenderingContext,
     opacity = 1.0,
-    rgba255 = [255, 255, 255, 255],
+    rgba255 = new Uint8Array([255, 255, 255, 255]),
     visible = true
   ): NVMesh {
     let tris: number[] = []
@@ -1295,20 +1295,23 @@ export class NVMesh {
 
     if ('rgba255' in obj && obj.rgba255.length > 0) {
       // e.g. x3D format
-      rgba255 = Array.from(obj.rgba255)
+      //rgba255 = Array.from(obj.rgba255)
+      rgba255 = obj.rgba255
     }
     if ('colors' in obj && obj.colors && obj.colors.length === pts.length) {
-      rgba255 = []
       const n = pts.length / 3
+      rgba255 = new Uint8Array(n * 4)
       let c = 0
+      let k = 0
       for (let i = 0; i < n; i++) {
         // convert ThreeJS unit RGB to RGBA255
-        rgba255.push(obj.colors[c] * 255) // red
-        rgba255.push(obj.colors[c + 1] * 255) // green
-        rgba255.push(obj.colors[c + 2] * 255) // blue
-        rgba255.push(255) // alpha
+        rgba255[k++] = obj.colors[c] * 255 // red
+        rgba255[k++] = obj.colors[c + 1] * 255 // green
+        rgba255[k++] = obj.colors[c + 2] * 255 // blue
+        rgba255[k++] = 255 // alpha
         c += 3
       } // for i: each vertex
+      
     } // obj includes colors
     const npt = pts.length / 3
     const ntri = tris.length / 3
@@ -1437,7 +1440,7 @@ export class NVMesh {
     gl,
     name = '',
     opacity = 1.0,
-    rgba255 = [255, 255, 255, 255],
+    rgba255 = new Uint8Array([255, 255, 255, 255]),
     visible = true,
     layers = []
   }: Partial<LoadFromUrlParams> = {}): Promise<NVMesh> {
@@ -1511,7 +1514,7 @@ export class NVMesh {
     gl,
     name = '',
     opacity = 1.0,
-    rgba255 = [255, 255, 255, 255],
+    rgba255 = new Uint8Array([255, 255, 255, 255]),
     visible = true,
     layers = []
   }: Partial<LoadFromFileParams> = {}): Promise<NVMesh> {
@@ -1546,7 +1549,7 @@ export class NVMesh {
     gl,
     name = '',
     opacity = 1.0,
-    rgba255 = [255, 255, 255, 255],
+    rgba255 = new Uint8Array([255, 255, 255, 255]),
     visible = true,
     layers = []
   }: Partial<LoadFromBase64Params> = {}): Promise<NVMesh> {

--- a/src/nvmesh.ts
+++ b/src/nvmesh.ts
@@ -135,7 +135,7 @@ export class NVMesh {
   opacity: number
   visible: boolean
   meshShaderIndex = 0
-  offsetPt0: number[] | Uint32Array | null = null
+  offsetPt0: Uint32Array | null = null
 
   colormapInvert = false
   fiberGroupColormap: ColorMap | null = null
@@ -146,7 +146,7 @@ export class NVMesh {
   vaoFiber: WebGLVertexArrayObject
 
   pts: number[] | Float32Array
-  tris?: number[] | Uint32Array
+  tris?: Uint32Array
   layers: NVMeshLayer[]
   type = MeshType.MESH
 
@@ -207,7 +207,7 @@ export class NVMesh {
    */
   constructor(
     pts: number[] | Float32Array,
-    tris: number[] | Uint32Array,
+    tris: Uint32Array,
     name = '',
     rgba255 = new Uint8Array([255, 255, 255, 255]),
     opacity = 1.0,
@@ -1172,8 +1172,8 @@ export class NVMesh {
     rgba255 = new Uint8Array([255, 255, 255, 255]),
     visible = true
   ): NVMesh {
-    let tris: number[] = []
-    let pts: number[] = []
+    let tris: Uint32Array = new Uint32Array([])
+    let pts: Float32Array = new Float32Array([]) 
     let anatomicalStructurePrimary = ''
     let obj: TCK | TRACT | TT | TRX | TRK | GII | MZ3 | X3D | VTK | DefaultMeshType
     const re = /(?:\.([^.]+))?$/
@@ -1259,7 +1259,8 @@ export class NVMesh {
         rgba255[3] = -1.0
         return new NVMesh(
           Array.from(obj.pts),
-          Array.from(obj.offsetPt0),
+          //Array.from(obj.offsetPt0),
+          obj.offsetPt0,
           name,
           rgba255, // colormap,
           opacity, // opacity,
@@ -1289,8 +1290,8 @@ export class NVMesh {
       throw new Error('indices not loaded')
     }
 
-    pts = Array.from(obj.positions)
-    tris = Array.from(obj.indices)
+    pts = new Float32Array(obj.positions)// Array.from(obj.positions)
+    tris = new Uint32Array(obj.indices)//Array.from()
 
     if ('rgba255' in obj && obj.rgba255.length > 0) {
       // e.g. x3D format

--- a/src/nvmesh.ts
+++ b/src/nvmesh.ts
@@ -280,6 +280,9 @@ export class NVMesh {
       this.dpg = dpg
       this.dps = dps
       this.dpv = dpv
+      if (dpg) this.initValuesArray(dpg)
+      if (dps) this.initValuesArray(dps)
+      if (dpv) this.initValuesArray(dpv)
       this.offsetPt0 = tris
       this.updateFibers(gl)
       // define VAO
@@ -307,6 +310,18 @@ export class NVMesh {
     this.rgba255 = rgba255
     this.tris = tris
     this.updateMesh(gl)
+  }
+
+  initValuesArray(va: ValuesArray): ValuesArray {
+    for (let i = 0; i < va.length; i++) {
+      const mn = va[i].vals.reduce((acc, current) => Math.min(acc, current))
+      const mx = va[i].vals.reduce((acc, current) => Math.max(acc, current))
+      va[i].global_min = mn
+      va[i].global_max = mx
+      va[i].cal_min = mn
+      va[i].cal_max = mx
+    }
+    return va
   }
 
   // given streamlines (which webGL renders as a single pixel), extrude to cylinders
@@ -546,7 +561,7 @@ export class NVMesh {
     } // direction2rgb()
     // Determine color: local, global, dps0, dpv0, etc.
     const fiberColor = this.fiberColor.toLowerCase()
-    let dps: number[] | null = null
+    let dps: Float32Array | null = null
     let dpv: ValuesArray[0] | null = null
     if (fiberColor.startsWith('dps') && this.dps && this.dps.length > 0) {
       const n = parseInt(fiberColor.substring(3))

--- a/src/nvmesh.ts
+++ b/src/nvmesh.ts
@@ -431,7 +431,7 @@ export class NVMesh {
     // each streamline with n nodes has n-1 cylinders (fencepost)
     // each triangle defined by three indices, each referring to a vertex
     const nidx = (n_line_vtx - n_streamlines) * cyl_sides * 2 * 3
-    const idxs = new Int32Array(nidx)
+    const idxs = new Uint32Array(nidx)
     let idx = 0
     vtx = 0
     for (let i = 1; i < n_count; i++) {
@@ -469,7 +469,7 @@ export class NVMesh {
     // no need to release: https://registry.khronos.org/OpenGL-Refpages/gl4/html/glBufferData.xhtml
     // any pre-existing data store is deleted
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.indexBuffer)
-    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Int32Array(idxs), gl.STATIC_DRAW)
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint32Array(idxs), gl.STATIC_DRAW)
     gl.bindBuffer(gl.ARRAY_BUFFER, this.vertexBuffer)
     gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(f32), gl.STATIC_DRAW)
     this.indexCount = nidx
@@ -1062,7 +1062,7 @@ export class NVMesh {
     } // isAdditiveBlend
     // generate webGL buffers and vao
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.indexBuffer)
-    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Int32Array(this.tris), gl.STATIC_DRAW)
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint32Array(this.tris), gl.STATIC_DRAW)
     gl.bindBuffer(gl.ARRAY_BUFFER, this.vertexBuffer)
     gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(posNormClr), gl.STATIC_DRAW)
     this.indexCount = this.tris.length

--- a/src/nvmesh.ts
+++ b/src/nvmesh.ts
@@ -1118,7 +1118,7 @@ export class NVMesh {
 
   // Each streamline vertex has color, normal and position attributes
   // Interleaved Vertex Data https://developer.apple.com/library/archive/documentation/3DDrawing/Conceptual/OpenGLES_ProgrammingGuide/TechniquesforWorkingwithVertexData/TechniquesforWorkingwithVertexData.html
-  generatePosNormClr(pts: number[] | Float32Array, tris: number[] | Uint32Array, rgba255: Uint8Array): Float32Array {
+  generatePosNormClr(pts: Float32Array, tris: Uint32Array, rgba255: Uint8Array): Float32Array {
     if (pts.length < 3 || rgba255.length < 4) {
       log.error('Catastrophic failure generatePosNormClr()')
       log.debug('this', this)
@@ -1316,7 +1316,7 @@ export class NVMesh {
     if (ntri < 1 || npt < 3) {
       throw new Error('Mesh should have at least one triangle and three vertices')
     }
-    rgba255[3] = Math.max(1, rgba255[3]) //mesh not streamline
+    rgba255[3] = Math.max(1, rgba255[3]) // mesh not streamline
     const nvm = new NVMesh(
       pts,
       tris,

--- a/src/nvmesh.ts
+++ b/src/nvmesh.ts
@@ -98,7 +98,7 @@ type BaseLoadParams = {
   // the opacity for this image. default is 1
   opacity: number
   // the base color of the mesh. RGBA values from 0 to 255. Default is white
-  rgba255: Uint8Array
+  rgba255: number[] | Uint8Array
   // whether or not this image is to be visible
   visible: boolean
   // layers of the mesh to load
@@ -1439,7 +1439,7 @@ export class NVMesh {
     gl,
     name = '',
     opacity = 1.0,
-    rgba255 = new Uint8Array([255, 255, 255, 255]),
+    rgba255 = [255, 255, 255, 255],
     visible = true,
     layers = []
   }: Partial<LoadFromUrlParams> = {}): Promise<NVMesh> {
@@ -1472,7 +1472,7 @@ export class NVMesh {
     // let tris = [];
     // var pts = [];
     const buffer = await response.arrayBuffer()
-    const nvmesh = await this.readMesh(buffer, name, gl, opacity, rgba255, visible)
+    const nvmesh = await this.readMesh(buffer, name, gl, opacity, new Uint8Array(rgba255), visible)
 
     if (!layers || layers.length < 1) {
       return nvmesh
@@ -1513,7 +1513,7 @@ export class NVMesh {
     gl,
     name = '',
     opacity = 1.0,
-    rgba255 = new Uint8Array([255, 255, 255, 255]),
+    rgba255 = [255, 255, 255, 255],
     visible = true,
     layers = []
   }: Partial<LoadFromFileParams> = {}): Promise<NVMesh> {
@@ -1525,7 +1525,7 @@ export class NVMesh {
     }
 
     const buffer = await NVMesh.readFileAsync(file)
-    const nvmesh = NVMesh.readMesh(buffer, name, gl, opacity, rgba255, visible)
+    const nvmesh = NVMesh.readMesh(buffer, name, gl, opacity, new Uint8Array(rgba255), visible)
 
     if (!layers || layers.length < 1) {
       return nvmesh
@@ -1548,7 +1548,7 @@ export class NVMesh {
     gl,
     name = '',
     opacity = 1.0,
-    rgba255 = new Uint8Array([255, 255, 255, 255]),
+    rgba255 = [255, 255, 255, 255],
     visible = true,
     layers = []
   }: Partial<LoadFromBase64Params> = {}): Promise<NVMesh> {
@@ -1571,7 +1571,7 @@ export class NVMesh {
     }
 
     const buffer = base64ToArrayBuffer(base64)
-    const nvmesh = await NVMesh.readMesh(buffer, name, gl, opacity, rgba255, visible)
+    const nvmesh = await NVMesh.readMesh(buffer, name, gl, opacity, new Uint8Array(rgba255), visible)
 
     if (!layers || layers.length < 1) {
       return nvmesh

--- a/src/nvmesh.ts
+++ b/src/nvmesh.ts
@@ -280,9 +280,15 @@ export class NVMesh {
       this.dpg = dpg
       this.dps = dps
       this.dpv = dpv
-      if (dpg) this.initValuesArray(dpg)
-      if (dps) this.initValuesArray(dps)
-      if (dpv) this.initValuesArray(dpv)
+      if (dpg) {
+        this.initValuesArray(dpg)
+      }
+      if (dps) {
+        this.initValuesArray(dps)
+      }
+      if (dpv) {
+        this.initValuesArray(dpv)
+      }
       this.offsetPt0 = tris
       this.updateFibers(gl)
       // define VAO
@@ -484,9 +490,9 @@ export class NVMesh {
     // no need to release: https://registry.khronos.org/OpenGL-Refpages/gl4/html/glBufferData.xhtml
     // any pre-existing data store is deleted
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.indexBuffer)
-    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint32Array(idxs), gl.STATIC_DRAW)
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, Uint32Array.from(idxs), gl.STATIC_DRAW)
     gl.bindBuffer(gl.ARRAY_BUFFER, this.vertexBuffer)
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(f32), gl.STATIC_DRAW)
+    gl.bufferData(gl.ARRAY_BUFFER, Float32Array.from(f32), gl.STATIC_DRAW)
     this.indexCount = nidx
   } // linesToCylinders
 
@@ -753,9 +759,9 @@ export class NVMesh {
       // copy streamlines to GPU
       this.indexCount = indices.length
       gl.bindBuffer(gl.ARRAY_BUFFER, this.vertexBuffer)
-      gl.bufferData(gl.ARRAY_BUFFER, new Uint32Array(posClrU32), gl.STATIC_DRAW)
+      gl.bufferData(gl.ARRAY_BUFFER, Uint32Array.from(posClrU32), gl.STATIC_DRAW)
       gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.indexBuffer)
-      gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint32Array(indices), gl.STATIC_DRAW)
+      gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, Uint32Array.from(indices), gl.STATIC_DRAW)
     }
   } // updateFibers()
 
@@ -1077,9 +1083,9 @@ export class NVMesh {
     } // isAdditiveBlend
     // generate webGL buffers and vao
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.indexBuffer)
-    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint32Array(this.tris), gl.STATIC_DRAW)
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, Uint32Array.from(this.tris), gl.STATIC_DRAW)
     gl.bindBuffer(gl.ARRAY_BUFFER, this.vertexBuffer)
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(posNormClr), gl.STATIC_DRAW)
+    gl.bufferData(gl.ARRAY_BUFFER, Float32Array.from(posNormClr), gl.STATIC_DRAW)
     this.indexCount = this.tris.length
     this.vertexCount = this.pts.length
   } // updateMesh()

--- a/src/nvmesh.ts
+++ b/src/nvmesh.ts
@@ -1206,7 +1206,7 @@ export class NVMesh {
       }
       if (typeof obj === 'undefined') {
         const pts = new Float32Array([0, 0, 0, 0, 0, 0])
-        const offsetPt0 = [0]
+        const offsetPt0 = new Uint32Array([0])
         obj = { pts, offsetPt0 }
         log.error('Creating empty tracts')
       }

--- a/src/nvmesh.ts
+++ b/src/nvmesh.ts
@@ -145,7 +145,7 @@ export class NVMesh {
   vao: WebGLVertexArrayObject
   vaoFiber: WebGLVertexArrayObject
 
-  pts: number[] | Float32Array
+  pts: Float32Array
   tris?: Uint32Array
   layers: NVMeshLayer[]
   type = MeshType.MESH
@@ -206,7 +206,7 @@ export class NVMesh {
    * @param anatomicalStructurePrimary - region for mesh. Default is an empty string
    */
   constructor(
-    pts: number[] | Float32Array,
+    pts: Float32Array,
     tris: Uint32Array,
     name = '',
     rgba255 = new Uint8Array([255, 255, 255, 255]),
@@ -1173,7 +1173,7 @@ export class NVMesh {
     visible = true
   ): NVMesh {
     let tris: Uint32Array = new Uint32Array([])
-    let pts: Float32Array = new Float32Array([]) 
+    let pts: Float32Array = new Float32Array([])
     let anatomicalStructurePrimary = ''
     let obj: TCK | TRACT | TT | TRX | TRK | GII | MZ3 | X3D | VTK | DefaultMeshType
     const re = /(?:\.([^.]+))?$/
@@ -1256,10 +1256,9 @@ export class NVMesh {
       obj = NVMeshLoaders.readVTK(buffer)
       if ('offsetPt0' in obj) {
         // VTK files used both for meshes and streamlines
-        rgba255[3] = -1.0
+        rgba255[3] = 0.0
         return new NVMesh(
-          Array.from(obj.pts),
-          //Array.from(obj.offsetPt0),
+          obj.pts,
           obj.offsetPt0,
           name,
           rgba255, // colormap,
@@ -1290,8 +1289,8 @@ export class NVMesh {
       throw new Error('indices not loaded')
     }
 
-    pts = new Float32Array(obj.positions)// Array.from(obj.positions)
-    tris = new Uint32Array(obj.indices)//Array.from()
+    pts = obj.positions
+    tris = obj.indices
 
     if ('rgba255' in obj && obj.rgba255.length > 0) {
       // e.g. x3D format
@@ -1317,6 +1316,7 @@ export class NVMesh {
     if (ntri < 1 || npt < 3) {
       throw new Error('Mesh should have at least one triangle and three vertices')
     }
+    rgba255[3] = Math.max(1, rgba255[3]) //mesh not streamline
     const nvm = new NVMesh(
       pts,
       tris,

--- a/src/nvmesh.ts
+++ b/src/nvmesh.ts
@@ -1295,7 +1295,7 @@ export class NVMesh {
 
     if ('rgba255' in obj && obj.rgba255.length > 0) {
       // e.g. x3D format
-      rgba255 = obj.rgba255
+      rgba255 = Array.from(obj.rgba255)
     }
     if ('colors' in obj && obj.colors && obj.colors.length === pts.length) {
       rgba255 = []


### PR DESCRIPTION
@jens-ox this PR uses typed arrays for WebGL meshes, as you note in your [PR 937](https://github.com/niivue/niivue/pull/937). The number[] arrays are still used for some transient usage (where the larger memory footprint has less impact than long term storage). However, all mesh indices are unified as Uint32 and all mesh vertex positions are unified as Float32. I think this addresses the `help needed` request from your PR. 
