### PR TITLE
Fix clone method to generate a new ID

### DIFF
--- a/src/nvimage/index.ts
+++ b/src/nvimage/index.ts
@@ -3013,7 +3013,10 @@ export class NVImage {
    */
   clone(): NVImage {
     const clonedImage = new NVImage()
-    clonedImage.id = this.id
+    // important! the clone should have a new ID to avoid conflicts
+    // when referencing images by ID. A user could add the cloned
+    // image as a viewable volume in any order.
+    clonedImage.id = uuidv4()
     clonedImage.hdr = Object.assign({}, this.hdr)
     clonedImage.img = this.img!.slice()
     clonedImage.calculateRAS()

--- a/tests/unit/nvimage.test.ts
+++ b/tests/unit/nvimage.test.ts
@@ -28,3 +28,13 @@ test("nvimage zerosLike", () => {
     expect(JSON.stringify(image.hdr)).toBe(JSON.stringify(zeroImage.hdr))
     expect(zeroImage.img!.every((item: number) => item === 0)).toBeTruthy()
 })
+
+test("nvimage clone has unique ID", () => {
+    const name = "mni152.nii.gz"
+    const dataBuffer = readFileSync(path.join("./tests/images/", name))
+    const image = new NVImage(
+        dataBuffer.buffer,
+        name)
+    const clone = image.clone()
+    expect(clone.id).not.toBe(image.id)
+})


### PR DESCRIPTION
This PR ensures that a new ID is given to cloned images in order to avoid ID based conflicts. 

A new unit test has been added for NVImage as well that will make sure this issue doesn't happen in the future. 

List of fixed issues (if they exist):

- closes #945 
