### PR TITLE
better logic for dragMode in touchEnd

### DIFF
--- a/src/niivue/index.ts
+++ b/src/niivue/index.ts
@@ -1356,12 +1356,21 @@ export class Niivue {
     }
     if (this.uiData.isDragging) {
       this.uiData.isDragging = false
-      // if (this.opts.isDragShowsMeasurementTool) return;
-      if (this.opts.dragMode !== DRAG_MODE.contrast) {
+      // if drag mode is contrast, and the user double taps and drags...
+      if (this.opts.dragMode === DRAG_MODE.contrast) {
+        this.calculateNewRange()
+        this.refreshLayers(this.volumes[0], 0)
+      } else if (this.opts.dragMode === DRAG_MODE.callbackOnly) {
+        // if the drag mode is callback only, then we don't want to change the brightness and contrast
+        // callback only is useful for the custom machine learning related callbacks
+        const fracStart = this.canvasPos2frac([this.uiData.dragStart[0], this.uiData.dragStart[1]])
+        const fracEnd = this.canvasPos2frac([this.uiData.dragEnd[0], this.uiData.dragEnd[1]])
+        // just use the generateMouseUpCallback since it
+        // does everything we need (same as the behaviour in mouseUpListener)
+        this.generateMouseUpCallback(fracStart, fracEnd)
+      } else {
         return
       }
-      this.calculateNewRange()
-      this.refreshLayers(this.volumes[0], 0)
     }
     // mouseUp generates this.drawScene();
     this.mouseUpListener()

--- a/src/niivue/index.ts
+++ b/src/niivue/index.ts
@@ -1360,17 +1360,12 @@ export class Niivue {
       if (this.opts.dragMode === DRAG_MODE.contrast) {
         this.calculateNewRange()
         this.refreshLayers(this.volumes[0], 0)
-      } else if (this.opts.dragMode === DRAG_MODE.callbackOnly) {
-        // if the drag mode is callback only, then we don't want to change the brightness and contrast
-        // callback only is useful for the custom machine learning related callbacks
-        const fracStart = this.canvasPos2frac([this.uiData.dragStart[0], this.uiData.dragStart[1]])
-        const fracEnd = this.canvasPos2frac([this.uiData.dragEnd[0], this.uiData.dragEnd[1]])
-        // just use the generateMouseUpCallback since it
-        // does everything we need (same as the behaviour in mouseUpListener)
-        this.generateMouseUpCallback(fracStart, fracEnd)
-      } else {
-        return
       }
+      const fracStart = this.canvasPos2frac([this.uiData.dragStart[0], this.uiData.dragStart[1]])
+      const fracEnd = this.canvasPos2frac([this.uiData.dragEnd[0], this.uiData.dragEnd[1]])
+      // just use the generateMouseUpCallback since it
+      // does everything we need (same as the behaviour in mouseUpListener)
+      this.generateMouseUpCallback(fracStart, fracEnd)
     }
     // mouseUp generates this.drawScene();
     this.mouseUpListener()


### PR DESCRIPTION
add `generateMouseUpCallback` behaviour to `touchEndListener`. This enables the same behaviour that we see in `mouseUpListener` by reusing our existing functions. 

Also updated the handling of different `DRAG_MODE` values in the `touchEndListener` event. 
