### PR TITLE
Fix atlas saving/loading and color rendering for colormaplabel

### DIFF
--- a/demos/features/document.atlas.html
+++ b/demos/features/document.atlas.html
@@ -38,6 +38,9 @@
     <input type="range" min="10" max="75" value="25" class="slider" id="fiberCalMin" />
     <button id="about">Save NVD</button>
     <button id="clear">Clear</button>
+    <button id="update">Update</button>
+    <button id="info">Info</button>
+    <button id="colormap">Set Colormap</button>
   </header>
   <main id="canvas-container">
     <canvas id="gl1"></canvas>
@@ -78,7 +81,28 @@
       nv1.opts.yoke3Dto2DZoom = true;
     }
 
-    var volumeList1 = [{ url: "../images/mni152.nii.gz" }, { url: "../images/aal.nii.gz" }];
+    update.onclick = async function() {
+      nv1.updateGLVolume();
+    }
+
+    info.onclick = function() {
+      for(const vol of nv1.volumes) {
+        console.log('vol', vol);
+      }
+    }
+
+    colormap.onclick = async function() {
+      console.log('setting colormap')
+      let cmap = await fetchJSON("../images/aal.json")
+      console.log('colormap loaded')
+      nv1.volumes[1].setColormapLabel(cmap)
+      nv1.updateGLVolume()
+      console.log('finished')
+    }
+
+    var volumeList1 = [
+      { url: "../images/mni152.nii.gz" }, 
+      { url: "../images/aal.nii.gz" }];
     let defaults = {
       backColor: [0, 0, 0, 1],
       show3Dcrosshair: true,
@@ -92,10 +116,19 @@
     }
     function handleLocationChange(data) {
       document.getElementById("location").innerHTML = data.string
+      
+
     }
 
-    function handleDocumentLoaded(doc) {
+    async function handleDocumentLoaded(doc) {
+      // nv1.updateGLVolume();
+      // for(let i = 0; i < nv1.volumes.length; i++) {
+      //   nv1.refreshLayers(nv1.volumes[i], i)
+      // }
       console.log("doc loaded", doc);
+      // let cmap = await fetchJSON("../images/aal.json")
+      // nv1.volumes[1].setColormapLabel(cmap)
+
     }
 
     var nv1 = new Niivue(defaults);
@@ -144,38 +177,7 @@
       nv1.setRenderAzimuthElevation(230,15)
       nv1.setSliceType(nv1.sliceTypeMultiplanar);
       nv1.opts.multiplanarForceRender = true;
-    //   var volumeList1 = [
-    //     {url: "../images/mni152.nii.gz"},
-    //     {
-    //       url: "../images/hippolr.nii.gz", 
-    //       colormap: "red",
-    //     }
-    //   ];
-    //   await nv1.loadVolumes(volumeList1);
-    //   var meshLayersList1 = [
-    //     {
-    //       url: "../images/pval.LH.nii.gz",
-    //       cal_min: 25,
-    //       cal_max: 35.0,
-    //       opacity: 1,
-    //     },
-    //   ];
-    //   await nv1.loadMeshes([
-    //     {
-    //       url: "../images/lh.pial",
-    //       rgba255: [212, 244, 212, 255],
-    //       layers: meshLayersList1,
-    //     },
-    //     { url: "../images/dpsv.trx" },
-    //     // {  url: "../images/aal.mz3"},
-    //     { url: "../images/TR_S_R.tt.gz"},
-    //     { url: "../images/connectome.jcon" },    
-    //     // { url: "../images/simplify_brain.obj"}    
-    //   ]);
-
-    // // console.log('fiber vertex intensity range:', nv1.meshes[0].dpv[0].global_min, nv1.meshes[0].dpv[0].global_max)
-    // nv1.setSelectionBoxColor([0, 1, 0, 0.5]);
-    // nv1.setClipPlane([0.2, 0, 120]);
+    
   </script>
 </body>
 

--- a/demos/features/document.atlas.html
+++ b/demos/features/document.atlas.html
@@ -141,7 +141,7 @@
     nv1.volumes[1].setColormapLabel(cmap)
     var layerList = [{url: "../images/mni152.SLF1_R.tsf"}];
     await nv1.loadMeshes([{ url: "../images/tract.SLF1_R.tck", layers: layerList,}]);
-    console.log("meshes at load", nv1.meshes);
+    // console.log("meshes at load", nv1.meshes);
     nv1.setMeshProperty(nv1.meshes[0].id, "fiberColor", "DPV0");
     nv1.setMeshProperty(nv1.meshes[0].id, "fiberDither", 0);
     nv1.setMeshProperty(nv1.meshes[0].id, "fiberRadius", 0.5);

--- a/demos/features/document.customdata.html
+++ b/demos/features/document.customdata.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+  <title>NiiVue</title>
+  <link rel="stylesheet" href="niivue.css" />
+  <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
+</head>
+
+<body>
+  <noscript>
+    <strong>niivue requires JavaScript.</strong>
+  </noscript>
+  <header>
+    <p>
+      Use the input box to set custom data in the document. Save the document and then drag and drop the document onto the canvas.
+    </p>
+    <label for="customData">Custom Data</label>
+    <input id="customData" value="hello, world!" />
+    <button id="save">Save NVD</button>
+    <button id="clear">Clear</button>
+    <button id="update">Update</button>
+    <button id="info">Info</button>
+    <button id="colormap">Set Colormap</button>
+    <label id="documentCustomData" style="color: cornflowerblue">Custom Data from Document</span>
+  </header>
+  <main id="canvas-container">
+    <canvas id="gl1"></canvas>
+  </main>
+  <footer id="location">&nbsp;</footer>
+  <script type="module" async>
+    import { Niivue, NVImage, NVMesh, NVMeshLoaders } from "../dist/index.js";
+
+    save.onclick = function () {
+      console.log("document on save", nv1.document);
+      const dataElement = document.getElementById('customData');
+      nv1.document.customData = dataElement.value
+      nv1.saveDocument("custom.nvd");
+    }
+
+    clear.onclick = async function () {
+      nv1 = new Niivue(defaults);
+      nv1.attachToCanvas(gl1);
+      nv1.opts.dragMode = nv1.dragModes.pan;
+      nv1.opts.multiplanarForceRender = true;
+      nv1.opts.yoke3Dto2DZoom = true;
+    }
+
+    update.onclick = async function () {
+      nv1.updateGLVolume();
+    }
+
+    info.onclick = function () {
+      for (const vol of nv1.volumes) {
+        console.log('vol', vol);
+      }
+    }
+
+    var volumeList1 = [
+      { url: "../images/mni152.nii.gz" },
+    ];
+    let defaults = {
+      backColor: [0, 0, 0, 1],
+      show3Dcrosshair: true,
+      onLocationChange: handleLocationChange,
+      onDocumentLoaded: handleDocumentLoaded
+    };
+    async function fetchJSON(fnm) {
+      const response = await fetch(fnm)
+      const js = await response.json()
+      return js
+    }
+    function handleLocationChange(data) {
+      document.getElementById("location").innerHTML = data.string
+    }
+
+    async function handleDocumentLoaded(doc) {
+      console.log(doc)
+      if (doc.customData) {
+        document.getElementById("documentCustomData").innerHTML = doc.customData
+      }
+    }
+
+    var nv1 = new Niivue(defaults);
+    nv1.attachToCanvas(gl1);
+    nv1.opts.dragMode = nv1.dragModes.pan;
+    nv1.opts.multiplanarForceRender = true;
+    nv1.opts.yoke3Dto2DZoom = true;
+    await nv1.loadVolumes(volumeList1);
+
+    nv1.setClipPlane([-0.12, 180, 40]);
+    nv1.setRenderAzimuthElevation(230, 15)
+    nv1.setSliceType(nv1.sliceTypeMultiplanar);
+    nv1.opts.multiplanarForceRender = true;
+
+  </script>
+</body>
+
+</html>

--- a/demos/index.html
+++ b/demos/index.html
@@ -625,6 +625,14 @@
           >Download a document with an atlas</a
         >
       </section>
+      <section>
+        <a
+          href="./features/document.customdata.html"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Download a document with custom data</a
+        >
+      </section>
     </section>
     <section>
       Machine Learning and AI helper functions

--- a/src/niivue/index.ts
+++ b/src/niivue/index.ts
@@ -3377,6 +3377,18 @@ export class Niivue {
         }
         const image = NVImage.loadFromBase64({ base64, ...imageOptions })
         if (image) {
+          if (image.colormapLabel) {
+            const length = Object.keys(image.colormapLabel.lut).length
+
+            // Create a new Uint8ClampedArray with the length of the object.
+            const uint8ClampedArray = new Uint8ClampedArray(length)
+
+            // Iterate over the object and set the values of the Uint8ClampedArray.
+            for (const key in image.colormapLabel.lut) {
+              uint8ClampedArray[key] = image.colormapLabel.lut[key]
+            }
+            image.colormapLabel.lut = uint8ClampedArray
+          }
           this.addVolume(image)
         }
       }

--- a/src/nvdocument.ts
+++ b/src/nvdocument.ts
@@ -234,6 +234,7 @@ export type DocumentData = {
   sceneData?: SceneData
   // TODO referenced in niivue/loadDocument
   connectomes?: string[]
+  customData?: string
 }
 
 export type ExportDocumentData = {
@@ -256,6 +257,7 @@ export type ExportDocumentData = {
   // TODO the following fields were missing in the typedef
   labels: NVLabel3D[]
   connectomes: string[]
+  customData: string
 }
 
 /**
@@ -428,6 +430,14 @@ export class NVDocument {
     this.data.labels = labels
   }
 
+  get customData(): string | undefined {
+    return this.data.customData
+  }
+
+  set customData(data: string) {
+    this.data.customData = data
+  }
+
   /**
    * Checks if document has an image by id
    */
@@ -515,6 +525,7 @@ export class NVDocument {
     }
 
     data.labels = [...this.data.labels]
+    data.customData = this.customData
 
     // volumes
     // TODO move this to a per-volume export function in NVImage?

--- a/src/nvimage/index.ts
+++ b/src/nvimage/index.ts
@@ -235,10 +235,7 @@ export class NVImage {
           if (nifti.isCompressed(dataBuffer as ArrayBuffer)) {
             imgRaw = nifti.readImage(this.hdr, nifti.decompress(dataBuffer as ArrayBuffer))
           } else {
-            // imgRaw = nifti.readImage(this.hdr, dataBuffer as ArrayBuffer) // this.hdr.vox_offset
-            console.log('this.hdr.vox_offset', this.hdr.vox_offset)
-            imgRaw = new Uint8Array(dataBuffer.slice(352) as ArrayBuffer)
-            console.log('imgRaw length', imgRaw.byteLength)
+            imgRaw = nifti.readImage(this.hdr, dataBuffer as ArrayBuffer)
           }
         }
         break
@@ -3563,7 +3560,7 @@ export class NVImage {
    */
   toUint8Array(drawingBytes: Uint8Array | null = null): Uint8Array {
     const isDrawing = drawingBytes !== null
-    const hdrBytes = hdrToArrayBuffer(this.hdr!, isDrawing)
+    const hdrBytes = hdrToArrayBuffer({ ...this.hdr!, vox_offset: 352 }, isDrawing)
 
     let drawingBytesToBeConverted = drawingBytes
     if (isDrawing) {
@@ -3640,7 +3637,6 @@ export class NVImage {
     const img8 = isDrawing ? (drawingBytesToBeConverted as Uint8Array) : new Uint8Array(this.img!.buffer)
     const opad = new Uint8Array(4)
     const odata = new Uint8Array(hdrBytes.length + opad.length + img8.length)
-    console.log('hdrBytes.length + opad.length + img8.length', hdrBytes.length, opad.length, img8.length)
     odata.set(hdrBytes)
     odata.set(opad, hdrBytes.length)
     odata.set(img8, hdrBytes.length + opad.length)

--- a/src/nvimage/index.ts
+++ b/src/nvimage/index.ts
@@ -235,7 +235,10 @@ export class NVImage {
           if (nifti.isCompressed(dataBuffer as ArrayBuffer)) {
             imgRaw = nifti.readImage(this.hdr, nifti.decompress(dataBuffer as ArrayBuffer))
           } else {
-            imgRaw = nifti.readImage(this.hdr, dataBuffer as ArrayBuffer)
+            // imgRaw = nifti.readImage(this.hdr, dataBuffer as ArrayBuffer) // this.hdr.vox_offset
+            console.log('this.hdr.vox_offset', this.hdr.vox_offset)
+            imgRaw = new Uint8Array(dataBuffer.slice(352) as ArrayBuffer)
+            console.log('imgRaw length', imgRaw.byteLength)
           }
         }
         break
@@ -3637,6 +3640,7 @@ export class NVImage {
     const img8 = isDrawing ? (drawingBytesToBeConverted as Uint8Array) : new Uint8Array(this.img!.buffer)
     const opad = new Uint8Array(4)
     const odata = new Uint8Array(hdrBytes.length + opad.length + img8.length)
+    console.log('hdrBytes.length + opad.length + img8.length', hdrBytes.length, opad.length, img8.length)
     odata.set(hdrBytes)
     odata.set(opad, hdrBytes.length)
     odata.set(img8, hdrBytes.length + opad.length)


### PR DESCRIPTION
Correctly saves and loads scenes with atlas and other .nii files with voxel offset not equal to 352
Converts color map label lookup table array into Uint8ClampedArray

List of fixed issues (if they exist):
- [Atlas not saving correctly](https://github.com/niivue/niivue/issues/976) 
- [Color not rendered from volumes with color map label](https://github.com/niivue/niivue/issues/977)
- [Add the capability to save custom data to NVDocument](https://github.com/niivue/niivue/issues/979)

