### PR TITLE
implement multiplanarShowRender

### DIFF
--- a/demos/features/additive.voxels.html
+++ b/demos/features/additive.voxels.html
@@ -98,7 +98,7 @@
       nv1.setAdditiveBlend(true);
       await nv1.loadVolumes(volumeList1);
       nv1.volumes[0].colorbarVisible = false; //hide colorbar for anatomical scan
-      nv1.opts.multiplanarForceRender = true;
+      nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;
       nv1.setInterpolation(true);
       nv1.updateGLVolume();
       checkAlpha.onchange();

--- a/demos/features/afni.html
+++ b/demos/features/afni.html
@@ -55,7 +55,7 @@
   nv1.loadVolumes(volumeList1)
   nv1.setSliceType(nv1.sliceTypeMultiplanar)
   nv1.graph.autoSizeMultiplanar = true
-  nv1.opts.multiplanarForceRender = true
+  nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS
   nv1.graph.normalizeValues = false
   nv1.graph.opacity = 1.0
   check1.onchange = function () {

--- a/demos/features/alphathreshold.html
+++ b/demos/features/alphathreshold.html
@@ -142,7 +142,7 @@
       nv1.volumes[1].alphaThreshold = true
       nv1.volumes[1].cal_minNeg = -6
       nv1.volumes[1].cal_maxNeg = -3.0
-      nv1.opts.multiplanarForceRender = true
+      nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS
       nv1.setInterpolation(true)
       nv1.updateGLVolume()
     </script>

--- a/demos/features/atlas.html
+++ b/demos/features/atlas.html
@@ -66,7 +66,7 @@
       nv1.attachTo("gl1")
       nv1.setInterpolation(true)
       nv1.opts.crosshairGap = 12
-      nv1.opts.multiplanarForceRender = true
+      nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS
       nv1.opts.dragMode = nv1.dragModes.pan
       nv1.opts.yoke3Dto2DZoom = true
       await nv1.loadVolumes(volumeList1)

--- a/demos/features/atlas.sparse.html
+++ b/demos/features/atlas.sparse.html
@@ -44,7 +44,7 @@
         document.getElementById("location").innerHTML = data.string
       }
       var nv1 = new niivue.Niivue({ onLocationChange: handleLocationChange })
-      nv1.opts.multiplanarForceRender = true
+      nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS
       nv1.opts.dragMode = nv1.dragModes.pan
       nv1.opts.yoke3Dto2DZoom = true
       nv1.attachTo("gl1")

--- a/demos/features/basic.multiplanar.html
+++ b/demos/features/basic.multiplanar.html
@@ -58,8 +58,6 @@
     dragAndDropEnabled: true,
     onLocationChange: handleIntensityChange,
   });
-  // nv1.setRadiologicalConvention(false);
-  // nv1.opts.multiplanarForceRender = true;
   nv1.attachTo("gl1");
   await nv1.loadVolumes(volumeList1);
   nv1.setSliceType(nv1.sliceTypeMultiplanar);

--- a/demos/features/cactus.html
+++ b/demos/features/cactus.html
@@ -190,12 +190,11 @@
   nv1.setRenderAzimuthElevation(120, 10);
   nv1.setSliceType(nv1.sliceTypeMultiplanar);
   nv1.setSliceMM(true);
-  nv1.opts.multiplanarForceRender = false;
+  nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;
   nv1.graph.autoSizeMultiplanar = true;
   nv1.graph.opacity = 1.0;
   nv1.drawOpacity = 0.5;
   nv1.opts.isColorbar = false;
-  nv1.opts.multiplanarForceRender = true;
   var volumeList1 = [{ url: "../images/cactus.nii.gz" }];
   await nv1.loadVolumes(volumeList1);
   //image specific settings
@@ -320,11 +319,11 @@
         nv1.setSliceType(nv1.sliceTypeSagittal);
       if (event.target.id === "|Render") nv1.setSliceType(nv1.sliceTypeRender);
       if (event.target.id === "|MultiPlanar") {
-        nv1.opts.multiplanarForceRender = false;
+        nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.NEVER;
         nv1.setSliceType(nv1.sliceTypeMultiplanar);
       }
       if (event.target.id === "|MultiPlanarRender") {
-        nv1.opts.multiplanarForceRender = true;
+        nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;
         nv1.setSliceType(nv1.sliceTypeMultiplanar);
       }
       toggleGroup(event.target.id);

--- a/demos/features/clipplanes.html
+++ b/demos/features/clipplanes.html
@@ -139,7 +139,7 @@
       nv1.setClipPlane([-0.12, 180, 40]);
       nv1.setRenderAzimuthElevation(230,15)
       nv1.setSliceType(nv1.sliceTypeMultiplanar);
-      nv1.opts.multiplanarForceRender = true;
+      nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;
       thickSlider.oninput()
       await nv1.loadVolumes(volumeList1);
       var meshLayersList1 = [

--- a/demos/features/clipplanes2.html
+++ b/demos/features/clipplanes2.html
@@ -126,7 +126,7 @@
       var nv1 = new niivue.Niivue(defaults)
       nv1.attachToCanvas(gl1)
       nv1.opts.dragMode = nv1.dragModes.pan
-      nv1.opts.multiplanarForceRender = true
+      nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS
       nv1.opts.yoke3Dto2DZoom = true
       var volumeList1 = [
         { url: "../images/mni152.nii.gz", cal_min: 30, cal_max: 80 },

--- a/demos/features/colormaps.html
+++ b/demos/features/colormaps.html
@@ -97,7 +97,7 @@ let cmap = {&#10; R: [0, 255, 0],&#10; G: [0, 0, 255],&#10; B: [0, 0, 0],&#10; A
   var nv1 = new niivue.Niivue({backColor: [0.3, 0.3, 0.3, 1]});
   nv1.attachTo("gl1");
   nv1.loadVolumes(volumeList1);
-  nv1.opts.multiplanarForceRender = true;
+  nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;
   nv1.opts.isColorbar = true;
   let cmaps = nv1.colormaps();
   let cmapEl = document.getElementById("colormaps");

--- a/demos/features/denoise.html
+++ b/demos/features/denoise.html
@@ -251,7 +251,7 @@ dialog {
       nv1.onImageLoaded = (volume) => {
         imgRaw = nv1.volumes[0].img.slice()
       }
-      nv1.opts.multiplanarForceRender = true
+      nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS
       nv1.opts.yoke3Dto2DZoom = true
       nv1.setInterpolation(true)
       await nv1.loadVolumes(volumeList1)

--- a/demos/features/document.atlas.html
+++ b/demos/features/document.atlas.html
@@ -77,7 +77,7 @@
       nv1 = new Niivue(defaults);
       nv1.attachToCanvas(gl1);
       nv1.opts.dragMode = nv1.dragModes.pan;
-      nv1.opts.multiplanarForceRender = true;
+      nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;
       nv1.opts.yoke3Dto2DZoom = true;
     }
 
@@ -134,7 +134,7 @@
     var nv1 = new Niivue(defaults);
     nv1.attachToCanvas(gl1);
     nv1.opts.dragMode = nv1.dragModes.pan;
-    nv1.opts.multiplanarForceRender = true;
+    nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;
     nv1.opts.yoke3Dto2DZoom = true;
     await nv1.loadVolumes(volumeList1);
     let cmap = await fetchJSON("../images/aal.json")
@@ -174,9 +174,8 @@
 
 
     nv1.setClipPlane([-0.12, 180, 40]);
-      nv1.setRenderAzimuthElevation(230,15)
-      nv1.setSliceType(nv1.sliceTypeMultiplanar);
-      nv1.opts.multiplanarForceRender = true;
+    nv1.setRenderAzimuthElevation(230,15)
+    nv1.setSliceType(nv1.sliceTypeMultiplanar);
     
   </script>
 </body>

--- a/demos/features/document.customdata.html
+++ b/demos/features/document.customdata.html
@@ -45,7 +45,7 @@
       nv1 = new Niivue(defaults);
       nv1.attachToCanvas(gl1);
       nv1.opts.dragMode = nv1.dragModes.pan;
-      nv1.opts.multiplanarForceRender = true;
+      nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;
       nv1.opts.yoke3Dto2DZoom = true;
     }
 
@@ -87,14 +87,13 @@
     var nv1 = new Niivue(defaults);
     nv1.attachToCanvas(gl1);
     nv1.opts.dragMode = nv1.dragModes.pan;
-    nv1.opts.multiplanarForceRender = true;
+    nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;
     nv1.opts.yoke3Dto2DZoom = true;
     await nv1.loadVolumes(volumeList1);
 
     nv1.setClipPlane([-0.12, 180, 40]);
     nv1.setRenderAzimuthElevation(230, 15)
     nv1.setSliceType(nv1.sliceTypeMultiplanar);
-    nv1.opts.multiplanarForceRender = true;
 
   </script>
 </body>

--- a/demos/features/document.drawing.html
+++ b/demos/features/document.drawing.html
@@ -177,7 +177,7 @@
   nv1.setRenderAzimuthElevation(120, 10);
   nv1.setSliceType(nv1.sliceTypeMultiplanar);
   nv1.setSliceMM(true);
-  nv1.opts.multiplanarForceRender = false;
+  nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;
   nv1.graph.autoSizeMultiplanar = true;
   nv1.graph.opacity = 1.0;
   nv1.drawOpacity = 0.5;
@@ -289,11 +289,11 @@
         nv1.setSliceType(nv1.sliceTypeSagittal);
       if (event.target.id === "|Render") nv1.setSliceType(nv1.sliceTypeRender);
       if (event.target.id === "|MultiPlanar") {
-        nv1.opts.multiplanarForceRender = false;
+        nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.NEVER;
         nv1.setSliceType(nv1.sliceTypeMultiplanar);
       }
       if (event.target.id === "|MultiPlanarRender") {
-        nv1.opts.multiplanarForceRender = true;
+        nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;
         nv1.setSliceType(nv1.sliceTypeMultiplanar);
       }
       toggleGroup(event.target.id);

--- a/demos/features/draw.ui.html
+++ b/demos/features/draw.ui.html
@@ -190,7 +190,7 @@
   nv1.setRenderAzimuthElevation(120, 10);
   nv1.setSliceType(nv1.sliceTypeMultiplanar);
   nv1.setSliceMM(true);
-  nv1.opts.multiplanarForceRender = false;
+  nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.NEVER;
   nv1.graph.autoSizeMultiplanar = true;
   nv1.graph.opacity = 1.0;
   nv1.drawOpacity = 0.5;
@@ -353,11 +353,11 @@
         nv1.setSliceType(nv1.sliceTypeSagittal);
       if (event.target.id === "|Render") nv1.setSliceType(nv1.sliceTypeRender);
       if (event.target.id === "|MultiPlanar") {
-        nv1.opts.multiplanarForceRender = false;
+        nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.NEVER;
         nv1.setSliceType(nv1.sliceTypeMultiplanar);
       }
       if (event.target.id === "|MultiPlanarRender") {
-        nv1.opts.multiplanarForceRender = true;
+        nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;
         nv1.setSliceType(nv1.sliceTypeMultiplanar);
       }
       toggleGroup(event.target.id);

--- a/demos/features/draw2.html
+++ b/demos/features/draw2.html
@@ -162,7 +162,7 @@
     onLocationChange: handleLocationChange,
   });
   nv1.setRadiologicalConvention(false);
-  nv1.opts.multiplanarForceRender = true;
+  nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;
   nv1.attachTo("gl1");
   await nv1.loadVolumes(volumeList1);
   nv1.setSliceType(nv1.sliceTypeMultiplanar);

--- a/demos/features/dsistudio.html
+++ b/demos/features/dsistudio.html
@@ -27,7 +27,7 @@
         onLocationChange: handleLocationChange,
       }
       var nv1 = new niivue.Niivue(defaults)
-      nv1.opts.multiplanarForceRender = true
+      nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS
       nv1.graph.opacity = 1.0
       nv1.graph.autoSizeMultiplanar = true
       nv1.attachToCanvas(gl1)

--- a/demos/features/freesurfer.html
+++ b/demos/features/freesurfer.html
@@ -275,11 +275,11 @@
         nv1.setSliceType(nv1.sliceTypeSagittal);
       if (event.target.id === "|Render") nv1.setSliceType(nv1.sliceTypeRender);
       if (event.target.id === "|MultiPlanar") {
-        nv1.opts.multiplanarForceRender = false;
+        nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.AUTO;
         nv1.setSliceType(nv1.sliceTypeMultiplanar);
       }
       if (event.target.id === "|MultiPlanarRender") {
-        nv1.opts.multiplanarForceRender = true;
+        nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;
         nv1.setSliceType(nv1.sliceTypeMultiplanar);
       }
       toggleGroup(event.target.id);

--- a/demos/features/labels.connectomes.html
+++ b/demos/features/labels.connectomes.html
@@ -129,7 +129,7 @@
   var nv1 = new niivue.Niivue({ show3Dcrosshair: true, isColorbar: true });
   nv1.attachTo("gl1");
   nv1.setSliceType(nv1.sliceTypeMultiplanar);
-  nv1.opts.multiplanarForceRender = true;
+  nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;
   nv1.opts.meshXRay = 0.2;
   await nv1.loadVolumes(volumeList1);
   nv1.setClipPlane([-0.1, 270, 0]);

--- a/demos/features/labels.html
+++ b/demos/features/labels.html
@@ -58,7 +58,7 @@
     drop.onchange = setSliceType;
 
     var nv1 = new niivue.Niivue();
-    nv1.opts.multiplanarForceRender = true;
+    nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;
     nv1.attachTo("gl1");
     nv1.loadVolumes(volumeList1);
     nv1.addLabel("Insula", {textScale: 2.0, textAlignment: niivue.LabelTextAlignment.CENTER}, [0.0, 0.0, 0.0]);

--- a/demos/features/layout.html
+++ b/demos/features/layout.html
@@ -15,8 +15,6 @@
       >
     </noscript>
     <header>
-      <label for="renderCheck">Force Render</label>
-      <input type="checkbox" id="renderCheck" unchecked />
       <label for="timelineCheck">Timeline</label>
       <input type="checkbox" id="timelineCheck" unchecked />
       <label for="padSlider">Padding</label>
@@ -28,13 +26,20 @@
         class="slider"
         id="padSlider"
       />
-      <label for="layout">Layout</label>
-      <select id="layout">
+      <label for="layoutSelect">Layout</label>
+      <select id="layoutSelect">
         <option value="0" selected>Auto</option>
         <option value="1">Column</option>
         <option value="2">Grid</option>
         <option value="3">Row</option>
       </select>
+      <label for="renderingSelect">Rendering</label>
+      <select id="renderingSelect">
+        <option value="0">Never</option>
+        <option value="1">Always</option>
+        <option value="2" selected>Auto</option>
+      </select>
+
     </header>
     <main id="container">
       <canvas id="gl1"></canvas>
@@ -46,16 +51,16 @@
   padSlider.oninput = function () {
     nv1.setMultiplanarPadPixels(this.value);
   };
-  renderCheck.onchange = function () {
-    nv1.opts.multiplanarForceRender = this.checked;
-    nv1.drawScene();
-  }
   timelineCheck.onchange = function () {
     nv1.graph.autoSizeMultiplanar = this.checked;
     nv1.drawScene();
   }
-  layout.onchange = function () {
+  layoutSelect.onchange = function () {
     nv1.setMultiplanarLayout(Number(this.value));
+  }
+  renderingSelect.onchange = function () {
+    nv1.opts.multiplanarShowRender =  Number(this.value);
+    nv1.drawScene();
   }
   var volumeList1 = [{url: "../images/pcasl.nii.gz"},];
   let opts = {

--- a/demos/features/modulateAfni.html
+++ b/demos/features/modulateAfni.html
@@ -111,7 +111,7 @@
       }
       var nv1 = new niivue.Niivue(defaults)
       nv1.setInterpolation(true)
-      nv1.opts.multiplanarForceRender = true
+      nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS
       nv1.attachTo("gl1")
       nv1.setSliceType(nv1.sliceTypeMultiplanar)
       await nv1.loadVolumes(volumeList1)

--- a/demos/features/multiuser.timeseries.html
+++ b/demos/features/multiuser.timeseries.html
@@ -73,7 +73,7 @@
       nv1.graph.autoSizeMultiplanar = true
       nv1.graph.normalizeValues = false
       nv1.graph.opacity = 1.0
-      nv1.opts.multiplanarForceRender = true
+      nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS
 
       var controller = new niivue.NVController(nv1)
       controller.onFrameChange = updateFrameValue

--- a/demos/features/pointset.html
+++ b/demos/features/pointset.html
@@ -218,7 +218,7 @@
       nv1.setRadiologicalConvention(false);
       nv1.attachTo("gl1");
       nv1.setSliceType(nv1.sliceTypeMultiplanar);
-      nv1.opts.multiplanarForceRender = true;
+      nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;
       nv1.graph.opacity = 1.0;
       nv1.opts.meshXRay = 0.2;
       nv1.setClipPlane([0.09, 180, 20]);

--- a/demos/features/save.custom.html.html
+++ b/demos/features/save.custom.html.html
@@ -418,7 +418,7 @@ div {
   var button = document.getElementById("save");
     button.onclick = saveAsHtml;
   nv1.setRadiologicalConvention(false);
-  nv1.opts.multiplanarForceRender = true;  
+  nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;  
   nv1.setSliceType(nv1.sliceTypeMultiplanar);
 <\/script>`;
     niivue.NVUtilities.download(html, "niivue.drawing.html", "application/html");
@@ -432,7 +432,7 @@ div {
     onLocationChange: handleLocationChange,
   });
   nv1.setRadiologicalConvention(false);
-  nv1.opts.multiplanarForceRender = true;
+  nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;
   nv1.attachTo("gl1");
   await nv1.loadVolumes(volumeList1);
   nv1.setSliceType(nv1.sliceTypeMultiplanar);

--- a/demos/features/segment.html
+++ b/demos/features/segment.html
@@ -89,7 +89,7 @@
         },
       ];
       await nv1.loadVolumes(volumeList1);
-      nv1.opts.multiplanarForceRender = true;
+      nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;
       nv1.setSliceType(nv1.sliceTypeMultiplanar);
       nv1.graph.autoSizeMultiplanar = true;
       nv1.updateGLVolume(); //apply labeled colormap

--- a/demos/features/shear.html
+++ b/demos/features/shear.html
@@ -49,8 +49,8 @@
       nv1.setRadiologicalConvention(false);
       nv1.attachTo("gl1");
       await nv1.loadVolumes(volumeList1);
+      nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS
       nv1.setSliceType(nv1.sliceTypeMultiplanar);
-      nv1.opts.multiplanarForceRender = true;
       document.getElementById("about").addEventListener("click", doAbout);
       function doAbout() {
         window.alert(
@@ -80,8 +80,6 @@
         edges: [1, 4, -3, 4, 0, 1, 0, 6, 0, 0, 1, 0, 0, 0, 0, 1],
       }; //connectome{}
       await nv1.loadConnectome(connectome);
-      nv1.setSliceType(nv1.sliceTypeMultiplanar);
-      nv1.opts.multiplanarForceRender = true;
     </script>
   </body>
 </html>

--- a/demos/features/shiny.volumes.html
+++ b/demos/features/shiny.volumes.html
@@ -107,7 +107,7 @@
       var nv1 = new niivue.Niivue(defaults)
       nv1.attachTo("gl1")
       nv1.setSliceType(nv1.sliceTypeRender)
-      nv1.opts.multiplanarForceRender = true
+      nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS
       nv1.setVolumeRenderIllumination(1.0)
       nv1.setClipPlane([0.3, 180, 20])
       await nv1.loadVolumes(volumeList1)
@@ -118,7 +118,6 @@
       matCaps.dispatchEvent(new Event("change"))
       nv1.setSliceType(nv1.sliceTypeMultiplanar)
       nv1.graph.autoSizeMultiplanar = true
-      nv1.opts.multiplanarForceRender = true
     </script>
   </body>
 </html>

--- a/demos/features/sync.bidirectional.html
+++ b/demos/features/sync.bidirectional.html
@@ -151,7 +151,7 @@
         backColor: [1, 1, 1, 1],
         dragMode: 3,
         sliceType: 3,
-        multiplanarForceRender: true,
+        multiplanarShowRender: niivue.SHOW_RENDER.ALWAYS
       });
       nv1.attachTo("gl1");
       var volumeList1 = [{ url: "../images/pcasl.nii.gz" }];
@@ -162,7 +162,7 @@
         backColor: [1, 1, 1, 1],
         dragMode: 3,
         sliceType: 3,
-        multiplanarForceRender: true,
+        multiplanarShowRender: niivue.SHOW_RENDER.ALWAYS
       });
       nv2.attachTo("gl2");
       var nv3 = new niivue.Niivue({
@@ -171,7 +171,7 @@
         backColor: [1, 1, 1, 1],
         dragMode: 3,
         sliceType: 3,
-        multiplanarForceRender: true,
+        multiplanarShowRender: niivue.SHOW_RENDER.ALWAYS
       });
       nv3.attachTo("gl3");
       var volumeList2 = [{ url: "../images/mni152.nii.gz" }];

--- a/demos/features/sync.mesh.html
+++ b/demos/features/sync.mesh.html
@@ -129,7 +129,7 @@
       await nv1.loadVolumes(volumeList1)
       await nv1.loadMeshes([{ url: "../images/BrainMesh_ICBM152.lh.mz3" }])
       nv1.setMeshShader(0, "Outline")
-      nv1.opts.multiplanarForceRender = true
+      nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS
       nv1.setSliceType(nv1.sliceTypeMultiplanar)
       nv1.setSliceMM(true)
       nv1.setClipPlane([0, 180, 40])
@@ -143,7 +143,7 @@
       nv2.setHighResolutionCapable(true)
       await nv2.loadVolumes(volumeList1)
       await nv2.loadMeshes([{ url: "../images/BrainMesh_ICBM152.lh.mz3" }])
-      nv2.opts.multiplanarForceRender = true
+      nv2.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS
       nv2.setSliceType(nv2.sliceTypeMultiplanar)
       nv2.setSliceMM(true)
       nv2.setClipPlane([0, 180, 40])

--- a/demos/features/timeseries.html
+++ b/demos/features/timeseries.html
@@ -56,7 +56,7 @@
   nv1.loadVolumes(volumeList1)
   nv1.setSliceType(nv1.sliceTypeMultiplanar)
   nv1.graph.autoSizeMultiplanar = true
-  nv1.opts.multiplanarForceRender = true
+  nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS
   nv1.graph.normalizeValues = false
   nv1.graph.opacity = 1.0
   check1.onchange = function () {

--- a/demos/features/timeseries2.html
+++ b/demos/features/timeseries2.html
@@ -51,7 +51,7 @@
   nv1.loadVolumes(volumeList1)
   nv1.setSliceType(nv1.sliceTypeMultiplanar)
   nv1.graph.autoSizeMultiplanar = true
-  nv1.opts.multiplanarForceRender = true
+  nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS
   nv1.graph.normalizeValues = false
   nv1.graph.opacity = 1.0
   check1.onchange = function () {

--- a/demos/features/torso.html
+++ b/demos/features/torso.html
@@ -90,7 +90,7 @@
         },
       ];
       await nv1.loadVolumes(volumeList1);
-      nv1.opts.multiplanarForceRender = true;
+      nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;
       nv1.graph.autoSizeMultiplanar = true;
       nv1.setClipPlane([-0.1, 270, 0]);
       let cmap = {

--- a/demos/features/tracts.atlas.html
+++ b/demos/features/tracts.atlas.html
@@ -56,7 +56,7 @@
       var nv1 = new niivue.Niivue(defaults)
       nv1.attachToCanvas(gl1)
       nv1.opts.dragMode = nv1.dragModes.pan
-      nv1.opts.multiplanarForceRender = true
+      nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS
       nv1.opts.yoke3Dto2DZoom = true
       await nv1.loadVolumes(volumeList1)
       await nv1.loadMeshes([{ url: "../images/yeh2022.trx"}])

--- a/demos/features/tracts.cylinder.html
+++ b/demos/features/tracts.cylinder.html
@@ -66,7 +66,7 @@
       var nv1 = new niivue.Niivue(defaults);
       nv1.attachToCanvas(gl1);
       nv1.opts.dragMode = nv1.dragModes.pan;
-      nv1.opts.multiplanarForceRender = true;
+      nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;
       nv1.opts.yoke3Dto2DZoom = true;
       await nv1.loadVolumes(volumeList1);
       await nv1.loadMeshes([{ url: "../images/dpsv.trx"}]);

--- a/demos/features/tracts.dsi.html
+++ b/demos/features/tracts.dsi.html
@@ -94,7 +94,7 @@
       var nv1 = new niivue.Niivue(defaults)
       nv1.attachToCanvas(gl1)
       nv1.opts.dragMode = nv1.dragModes.pan
-      nv1.opts.multiplanarForceRender = true
+      nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS
       nv1.opts.yoke3Dto2DZoom = true
       await nv1.loadVolumes(volumeList1)
       await nv1.loadMeshes([{ url: "../images/TR_S_R.tt.gz"}])

--- a/demos/features/tracts.mrtrix.html
+++ b/demos/features/tracts.mrtrix.html
@@ -93,7 +93,7 @@
       var nv1 = new niivue.Niivue(defaults);
       nv1.attachToCanvas(gl1);
       nv1.opts.dragMode = nv1.dragModes.pan;
-      nv1.opts.multiplanarForceRender = true;
+      nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;
       nv1.opts.yoke3Dto2DZoom = true;
       await nv1.loadVolumes(volumeList1);
       var layerList = [{url: "../images/mni152.SLF1_R.tsf"}];

--- a/demos/features/ui.html
+++ b/demos/features/ui.html
@@ -30,6 +30,7 @@
           <a class="viewBtn" id="|Sagittal">Sagittal</a>
           <a class="viewBtn" id="|Coronal">Coronal</a>
           <a class="viewBtn" id="|Render">Render</a>
+          <a class="viewBtn" id="|MultiPlanar">A+C+S</a>
           <a class="viewBtn dropdown-item-checked" id="|MultiPlanarRender"
             >A+C+S+R</a
           >
@@ -116,7 +117,7 @@
   nv1.setRenderAzimuthElevation(120, 10);
   nv1.setSliceType(nv1.sliceTypeMultiplanar);
   nv1.setSliceMM(true);
-  nv1.opts.multiplanarForceRender = true;
+  nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;
   nv1.graph.autoSizeMultiplanar = true;
   nv1.graph.opacity = 1.0;
   var volumeList1 = [{ url: "../images/mni152.nii.gz" }];
@@ -190,11 +191,11 @@
         nv1.setSliceType(nv1.sliceTypeSagittal);
       if (event.target.id === "|Render") nv1.setSliceType(nv1.sliceTypeRender);
       if (event.target.id === "|MultiPlanar") {
-        nv1.opts.multiplanarForceRender = false;
+        nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.NEVER;
         nv1.setSliceType(nv1.sliceTypeMultiplanar);
       }
       if (event.target.id === "|MultiPlanarRender") {
-        nv1.opts.multiplanarForceRender = true;
+        nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;
         nv1.setSliceType(nv1.sliceTypeMultiplanar);
       }
       toggleGroup(event.target.id);

--- a/demos/features/vox.aaAUTO.html
+++ b/demos/features/vox.aaAUTO.html
@@ -58,7 +58,7 @@
   });
   nv1.attachTo("gl1");
   nv1.opts.isColorbar = true;
-  nv1.opts.multiplanarForceRender = true;
+  nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;
   await nv1.loadVolumes(volumeList1);
   nv1.volumes[0].colorbarVisible = false; //hide colorbar for anatomical scan
   nv1.setSliceType(nv1.sliceTypeMultiplanar);

--- a/demos/features/vox.aaOFF.html
+++ b/demos/features/vox.aaOFF.html
@@ -58,7 +58,7 @@
   });
   nv1.attachTo("gl1", false);
   nv1.opts.isColorbar = true;
-  nv1.opts.multiplanarForceRender = true;
+  nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;
   await nv1.loadVolumes(volumeList1);
   nv1.volumes[0].colorbarVisible = false; //hide colorbar for anatomical scan
   nv1.setSliceType(nv1.sliceTypeMultiplanar);

--- a/demos/features/vox.aaON.html
+++ b/demos/features/vox.aaON.html
@@ -58,7 +58,7 @@
   });
   nv1.attachTo("gl1", true);
   nv1.opts.isColorbar = true;
-  nv1.opts.multiplanarForceRender = true;
+  nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS;
   await nv1.loadVolumes(volumeList1);
   nv1.volumes[0].colorbarVisible = false; //hide colorbar for anatomical scan
   nv1.setSliceType(nv1.sliceTypeMultiplanar);

--- a/demos/features/worldspace2.html
+++ b/demos/features/worldspace2.html
@@ -129,7 +129,10 @@
         .getElementById("check11")
         .addEventListener("change", doCheck11Click);
       function doCheck11Click() {
-        nv1.opts.multiplanarForceRender = this.checked;
+        if (this.checked)
+            nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.ALWAYS
+        else
+            nv1.opts.multiplanarShowRender = niivue.SHOW_RENDER.AUTO
         nv1.drawScene();
       }
 

--- a/src/index.html
+++ b/src/index.html
@@ -72,6 +72,7 @@
         NVImage,
         NVMesh,
         NVMeshLoaders,
+        SHOW_RENDER
       } from "./niivue/index.ts";
       async function addVolumeFromFiles(f) {
         console.log("attempting to open ", f[0].name);
@@ -121,7 +122,8 @@
       nv1.attachToCanvas(gl1);
       // multiplanarShowRender is the preferred option now, 
       // but multiplanarForceRender is still available for backwards compatibility
-      nv1.opts.multiplanarForceRender = true;
+      // previous use was: nv1.opts.multiplanarForceRender = true;
+      nv1.opts.multiplanarShowRender = SHOW_RENDER.ALWAYS
       nv1.opts.yoke3Dto2DZoom = true;
       await nv1.loadVolumes(volumeList1);
       var layerList = [{ url: "../demos/images/mni152.SLF1_R.tsf" }];

--- a/src/index.html
+++ b/src/index.html
@@ -123,7 +123,7 @@
       // multiplanarShowRender is the preferred option now, 
       // but multiplanarForceRender is still available for backwards compatibility
       // previous use was: nv1.opts.multiplanarForceRender = true;
-      nv1.opts.multiplanarShowRender = SHOW_RENDER.ALWAYS
+      nv1.opts.multiplanarShowRender = SHOW_RENDER.AUTO
       nv1.opts.yoke3Dto2DZoom = true;
       await nv1.loadVolumes(volumeList1);
       var layerList = [{ url: "../demos/images/mni152.SLF1_R.tsf" }];

--- a/src/index.html
+++ b/src/index.html
@@ -119,6 +119,8 @@
       };
       var nv1 = new Niivue(defaults);
       nv1.attachToCanvas(gl1);
+      // multiplanarShowRender is the preferred option now, 
+      // but multiplanarForceRender is still available for backwards compatibility
       nv1.opts.multiplanarForceRender = true;
       nv1.opts.yoke3Dto2DZoom = true;
       await nv1.loadVolumes(volumeList1);

--- a/src/niivue/index.ts
+++ b/src/niivue/index.ts
@@ -10160,6 +10160,27 @@ export class Niivue {
         this.draw2D([0, 0, 0, 0], 2)
       } else {
         // sliceTypeMultiplanar
+        let showRender = false
+        // this.opts.multiplanarForceRender is deprecated but was boolean.
+        // We now need to check if it is true. If so, then the user may not know
+        // about the new multiplanarShowRender option, so we need to show the render.
+        if (this.opts.multiplanarForceRender) {
+          showRender = true
+          // warn the user that the option is deprecated
+          log.warn(
+            'multiplanarForceRender is deprecated. Use multiplanarShowRender instead. Possible values are: "always", "auto", "never".'
+          )
+        } else {
+          //  check the now preferred multiplanarShowRender option.
+          // if the value is always, then show the render.
+          if (this.opts.multiplanarShowRender === 'always') {
+            showRender = true
+            // again, warn the user that we are using the new option
+            log.warn(
+              'multiplanarShowRender is set to always and multiplanarForceRender (deprecated) is false. We are assuming you prefer the non-deprecated option: multiplanarShowRender.'
+            )
+          }
+        }
         const isDrawPenDown = isFinite(this.drawPenLocation[0]) && this.opts.drawingEnabled
         const { volScale } = this.sliceScale()
         if (typeof this.opts.multiplanarPadPixels !== 'number') {
@@ -10208,7 +10229,7 @@ export class Niivue {
         }
         if (isDrawColumn) {
           let ltwh = ltwh1x3
-          if (this.opts.multiplanarForceRender || ltwh1x4[4] >= ltwh1x3[4]) {
+          if (showRender || (this.opts.multiplanarShowRender === 'auto' && ltwh1x4[4] >= ltwh1x3[4])) {
             ltwh = ltwh1x4
           } else {
             isDraw3D = false
@@ -10228,7 +10249,7 @@ export class Niivue {
           }
         } else if (isDrawRow) {
           let ltwh = ltwh3x1
-          if (this.opts.multiplanarForceRender || ltwh4x1[4] >= ltwh3x1[4]) {
+          if (showRender || (this.opts.multiplanarShowRender === 'auto' && ltwh4x1[4] >= ltwh3x1[4])) {
             ltwh = ltwh4x1
           } else {
             isDraw3D = false
@@ -10246,6 +10267,14 @@ export class Niivue {
             this.draw3D([ltwh[0] + sX + sX + sY + pad * 3, ltwh[1], ltwh[3], ltwh[3]])
           }
         } else if (isDrawGrid) {
+          // did the user turn off 3D render view in multiplanar?
+          if (!showRender) {
+            isDraw3D = false
+          }
+          // however, check if the user asked for auto
+          if (this.opts.multiplanarShowRender === 'auto') {
+            isDraw3D = true
+          }
           const ltwh = ltwh2x2
           const sX = volScale[0] * ltwh[4]
           const sY = volScale[1] * ltwh[4]

--- a/src/niivue/index.ts
+++ b/src/niivue/index.ts
@@ -7505,6 +7505,9 @@ export class Niivue {
       width = bulletMargin + longestTextLength
       width += horizontalMargin * 2
     }
+    if (width >= this.gl.canvas.width) {
+      return 0
+    }
     return width
   }
 

--- a/src/niivue/index.ts
+++ b/src/niivue/index.ts
@@ -70,6 +70,7 @@ import {
   NVConfigOptions,
   Scene,
   SLICE_TYPE,
+  SHOW_RENDER,
   DRAG_MODE,
   MULTIPLANAR_TYPE,
   DEFAULT_OPTIONS,
@@ -10167,18 +10168,25 @@ export class Niivue {
         if (this.opts.multiplanarForceRender) {
           showRender = true
           // warn the user that the option is deprecated
-          log.warn(
-            'multiplanarForceRender is deprecated. Use multiplanarShowRender instead. Possible values are: "always", "auto", "never".'
-          )
+          // log.warn(
+          //   'multiplanarForceRender is deprecated. Use multiplanarShowRender instead. Possible values are: "always", "auto", "never".'
+          // )
+          if (this.opts.multiplanarForceRender) {
+            this.opts.multiplanarShowRender = SHOW_RENDER.ALWAYS
+          } else {
+            this.opts.multiplanarShowRender = SHOW_RENDER.AUTO
+          }
+          // purge the deprecated option so it doesn't get used in saved scenes and documents
+          delete this.opts.multiplanarForceRender
         } else {
           //  check the now preferred multiplanarShowRender option.
           // if the value is always, then show the render.
-          if (this.opts.multiplanarShowRender === 'always') {
+          if (this.opts.multiplanarShowRender === SHOW_RENDER.ALWAYS) {
             showRender = true
-            // again, warn the user that we are using the new option
-            log.warn(
-              'multiplanarShowRender is set to always and multiplanarForceRender (deprecated) is false. We are assuming you prefer the non-deprecated option: multiplanarShowRender.'
-            )
+            // warn the user that we are using the new option
+            // log.warn(
+            //   'multiplanarShowRender is set to always and multiplanarForceRender (deprecated) is false. We are assuming you prefer the non-deprecated option: multiplanarShowRender.'
+            // )
           }
         }
         const isDrawPenDown = isFinite(this.drawPenLocation[0]) && this.opts.drawingEnabled
@@ -10229,7 +10237,7 @@ export class Niivue {
         }
         if (isDrawColumn) {
           let ltwh = ltwh1x3
-          if (showRender || (this.opts.multiplanarShowRender === 'auto' && ltwh1x4[4] >= ltwh1x3[4])) {
+          if (showRender || (this.opts.multiplanarShowRender === SHOW_RENDER.AUTO && ltwh1x4[4] >= ltwh1x3[4])) {
             ltwh = ltwh1x4
           } else {
             isDraw3D = false
@@ -10249,7 +10257,7 @@ export class Niivue {
           }
         } else if (isDrawRow) {
           let ltwh = ltwh3x1
-          if (showRender || (this.opts.multiplanarShowRender === 'auto' && ltwh4x1[4] >= ltwh3x1[4])) {
+          if (showRender || (this.opts.multiplanarShowRender === SHOW_RENDER.AUTO && ltwh4x1[4] >= ltwh3x1[4])) {
             ltwh = ltwh4x1
           } else {
             isDraw3D = false
@@ -10272,7 +10280,7 @@ export class Niivue {
             isDraw3D = false
           }
           // however, check if the user asked for auto
-          if (this.opts.multiplanarShowRender === 'auto') {
+          if (this.opts.multiplanarShowRender === SHOW_RENDER.AUTO) {
             isDraw3D = true
           }
           const ltwh = ltwh2x2

--- a/src/niivue/index.ts
+++ b/src/niivue/index.ts
@@ -10161,12 +10161,12 @@ export class Niivue {
         this.draw2D([0, 0, 0, 0], 2)
       } else {
         // sliceTypeMultiplanar
-        let showRender = false
+        let isShowRender = false
         // this.opts.multiplanarForceRender is deprecated but was boolean.
         // We now need to check if it is true. If so, then the user may not know
         // about the new multiplanarShowRender option, so we need to show the render.
         if (this.opts.multiplanarForceRender) {
-          showRender = true
+          isShowRender = true
           // warn the user that the option is deprecated
           // log.warn(
           //   'multiplanarForceRender is deprecated. Use multiplanarShowRender instead. Possible values are: "always", "auto", "never".'
@@ -10182,7 +10182,7 @@ export class Niivue {
           //  check the now preferred multiplanarShowRender option.
           // if the value is always, then show the render.
           if (this.opts.multiplanarShowRender === SHOW_RENDER.ALWAYS) {
-            showRender = true
+            isShowRender = true
             // warn the user that we are using the new option
             // log.warn(
             //   'multiplanarShowRender is set to always and multiplanarForceRender (deprecated) is false. We are assuming you prefer the non-deprecated option: multiplanarShowRender.'
@@ -10237,7 +10237,7 @@ export class Niivue {
         }
         if (isDrawColumn) {
           let ltwh = ltwh1x3
-          if (showRender || (this.opts.multiplanarShowRender === SHOW_RENDER.AUTO && ltwh1x4[4] >= ltwh1x3[4])) {
+          if (isShowRender || (this.opts.multiplanarShowRender === SHOW_RENDER.AUTO && ltwh1x4[4] >= ltwh1x3[4])) {
             ltwh = ltwh1x4
           } else {
             isDraw3D = false
@@ -10257,7 +10257,7 @@ export class Niivue {
           }
         } else if (isDrawRow) {
           let ltwh = ltwh3x1
-          if (showRender || (this.opts.multiplanarShowRender === SHOW_RENDER.AUTO && ltwh4x1[4] >= ltwh3x1[4])) {
+          if (isShowRender || (this.opts.multiplanarShowRender === SHOW_RENDER.AUTO && ltwh4x1[4] >= ltwh3x1[4])) {
             ltwh = ltwh4x1
           } else {
             isDraw3D = false
@@ -10276,7 +10276,7 @@ export class Niivue {
           }
         } else if (isDrawGrid) {
           // did the user turn off 3D render view in multiplanar?
-          if (!showRender) {
+          if (!isShowRender) {
             isDraw3D = false
           }
           // however, check if the user asked for auto

--- a/src/nvdocument.ts
+++ b/src/nvdocument.ts
@@ -19,6 +19,12 @@ export enum SLICE_TYPE {
   RENDER = 4
 }
 
+export enum SHOW_RENDER {
+  NEVER = 0,
+  ALWAYS = 1,
+  AUTO = 2
+}
+
 /**
  * Multi-planar layout
  * @ignore
@@ -90,7 +96,7 @@ export type NVConfigOptions = {
   multiplanarPadPixels: number
   // @deprecated
   multiplanarForceRender: boolean
-  multiplanarShowRender: 'always' | 'never' | 'auto'
+  multiplanarShowRender: SHOW_RENDER
   isRadiologicalConvention: boolean
   // string to allow infinity
   meshThicknessOn2D: number | string
@@ -171,7 +177,7 @@ export const DEFAULT_OPTIONS: NVConfigOptions = {
   multiplanarPadPixels: 0,
   // @deprecated
   multiplanarForceRender: false,
-  multiplanarShowRender: 'auto', // auto is the same behaviour as multiplanarForceRender: false
+  multiplanarShowRender: SHOW_RENDER.AUTO, // auto is the same behaviour as multiplanarForceRender: false
   isRadiologicalConvention: false,
   meshThicknessOn2D: Infinity,
   dragMode: DRAG_MODE.contrast,

--- a/src/nvdocument.ts
+++ b/src/nvdocument.ts
@@ -88,7 +88,9 @@ export type NVConfigOptions = {
   isColorbar: boolean
   isOrientCube: boolean
   multiplanarPadPixels: number
+  // @deprecated
   multiplanarForceRender: boolean
+  multiplanarShowRender: 'always' | 'never' | 'auto'
   isRadiologicalConvention: boolean
   // string to allow infinity
   meshThicknessOn2D: number | string
@@ -167,7 +169,9 @@ export const DEFAULT_OPTIONS: NVConfigOptions = {
   isColorbar: false,
   isOrientCube: false,
   multiplanarPadPixels: 0,
+  // @deprecated
   multiplanarForceRender: false,
+  multiplanarShowRender: 'auto', // auto is the same behaviour as multiplanarForceRender: false
   isRadiologicalConvention: false,
   meshThicknessOn2D: Infinity,
   dragMode: DRAG_MODE.contrast,


### PR DESCRIPTION
This PR implements the new option `multiplanarShowRender`. 

The main motivation for this new option is that the existing option, `multiplanarForceRender`, did not allow full control over the render tile slot when niivue is in multiplanar layout mode. 

I have implemented this in a way that preserves backwards compatibility with `multiplanarForceRender`. 

The logic is:
1. check if the user set `multiplanarForceRender=true`. 
2. if `multiplanarForceRender === true` then assume the user/developer has no knowledge of the new option `multiplanarShowRender`. NiiVue behaviour is identical to before. 
3. if `multiplanarForceRender === false` (the default value) then we inspect the value of `multiplanarShowRender`. 
4. if `multiplanarShowRender === 'always'` then we draw the render tile in multiplanar mode
5. if `multiplanarShowRender === 'never'` then we leave the render tile blank
6. if `multiplanarShowRender === 'auto'` (the default value) then we only draw the render tile if the NiiVue canvas aspect ratio allows us that space for free (this is how NiiVue worked prior to this change as well). 

So, basically, if someone sets `multiplanarForceRender=true` then we operate as if the new option does not exist. There is no behaviour change in NiiVue. 

If `multiplanarForceRender=false` and `multiplanarShowRender` is anything other than `auto` then we obey the user's wishes and do whatever `multiplanarShowRender` suggests.  

This backwards compatible implementation does not require any demo html updates since those will still work as before. 

List of fixed issues (if they exist):

- closes #1024 
