### PR TITLE
remove unused "media" property from typedoc.json

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -52,6 +52,5 @@
     "GitHub": "https://github.com/niivue/niivue",
     "npm": "https://www.npmjs.com/package/@niivue/niivue",
     
-  },
-  "media": "docs/media"
+  }
 }


### PR DESCRIPTION
This PR fixes the error preventing github actions from building and publishing the niivue docs and live demos

List of fixed issues (if they exist):

- Typedoc removed the `media` config option and now automatically detects media links (https://github.com/TypeStrong/typedoc/blob/e7d88cef87e15310972f1c407a5603a30acbb78d/CHANGELOG.md?plain=1#L107)
