### PR TITLE
add support for gamma syncing

### DIFF
--- a/demos/features/sync.bidirectional.html
+++ b/demos/features/sync.bidirectional.html
@@ -75,6 +75,16 @@
         <option value="2">Sync 3D</option>
         <option value="3" selected>Sync 2D and 3D</option>
       </select>
+      <!-- slider for gamma -->
+      <label for="gammaSlider">Gamma</label>
+      <input
+      type="range"
+      min="10"
+      max="400"
+      value="100"
+      class="slider"
+      id="gammaSlider"
+    />
     </header>
     <main>
       <div class='page-wrapper'>
@@ -116,6 +126,14 @@
         nv1.resizeListener();
         nv2.resizeListener();
         nv3.resizeListener();
+      }
+
+      gammaSlider.onchange = function() {
+        const v = parseFloat(gammaSlider.value) * 0.01
+        nv1.setGamma(v)
+        nv1.gl.canvas.focus()
+        nv1.sync()
+        nv1.gl.canvas.blur()
       }
 
       syncDrop.onchange = function() {

--- a/src/niivue/index.ts
+++ b/src/niivue/index.ts
@@ -956,10 +956,18 @@ export class Niivue {
     const thisMM = this.frac2mm(this.scene.crosshairPos)
     // if this.otherNV is an object, then it is a single Niivue instance
     if (this.otherNV instanceof Niivue) {
+      // gamma not dependent on 2d/3d
+      const thisGamma = this.scene.gamma
+      const otherGamma = this.otherNV.scene.gamma
+      if (thisGamma !== otherGamma) {
+        this.otherNV.setGamma(thisGamma)
+      }
+      // options specific to 2d rendering
       if (this.syncOpts['2d']) {
         this.otherNV.scene.crosshairPos = this.otherNV.mm2frac(thisMM)
         this.otherNV.scene.pan2Dxyzmm = vec4.clone(this.scene.pan2Dxyzmm)
       }
+      // options specific to 3d rendering
       if (this.syncOpts['3d']) {
         this.otherNV.scene.renderAzimuth = this.scene.renderAzimuth
         this.otherNV.scene.renderElevation = this.scene.renderElevation
@@ -971,6 +979,12 @@ export class Niivue {
       for (let i = 0; i < this.otherNV.length; i++) {
         if (this.otherNV[i] === this) {
           continue
+        }
+        // gamma not dependent on 2d/3d
+        const thisGamma = this.scene.gamma
+        const otherGamma = this.otherNV[i].scene.gamma
+        if (thisGamma !== otherGamma) {
+          this.otherNV[i].setGamma(thisGamma)
         }
         if (this.syncOpts['2d']) {
           this.otherNV[i].scene.crosshairPos = this.otherNV[i].mm2frac(thisMM)
@@ -6801,6 +6815,7 @@ export class Niivue {
    * @see {@link https://niivue.github.io/niivue/features/colormaps.html | live demo usage}
    */
   setGamma(gamma = 1.0): void {
+    this.scene.gamma = gamma
     cmapper.gamma = gamma
     this.updateGLVolume()
   }

--- a/src/nvdocument.ts
+++ b/src/nvdocument.ts
@@ -217,6 +217,7 @@ export const DEFAULT_OPTIONS: NVConfigOptions = {
 }
 
 type SceneData = {
+  gamma: number
   azimuth: number
   elevation: number
   crosshairPos: vec3
@@ -230,6 +231,7 @@ type SceneData = {
 }
 
 export const INITIAL_SCENE_DATA = {
+  gamma: 1.0,
   azimuth: 110,
   elevation: 10,
   crosshairPos: vec3.create(),
@@ -255,6 +257,7 @@ export type Scene = {
   pan2Dxyzmm: vec4
   _elevation?: number
   _azimuth?: number
+  gamma?: number
 }
 
 export type DocumentData = {


### PR DESCRIPTION
This PR adds the `gamma` value to the `scene` in `NVDocument`. This enables syncing of the `gamma` property when using the `broadcastTo` function of a `niivue` instance. 

see `demos/features/sync.bidirectional.html` for a reference of how this works in practice. 

- closes #1052 
