### PR TITLE
Issue1056

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -58,7 +58,21 @@
         class="slider"
         id="fiberCalMin"
       />
-      <button id="about">About</button>
+      <label for="layoutSelect">Layout</label>
+      <select id="layoutSelect">
+        <option value="0" selected>Auto</option>
+        <option value="1">Column</option>
+        <option value="2">Grid</option>
+        <option value="3">Row</option>
+      </select>
+      <label for="renderingSelect">Rendering</label>
+      <select id="renderingSelect">
+        <option value="0">Never</option>
+        <option value="1">Always</option>
+        <option value="2" selected>Auto</option>
+      </select>
+      <label for="equalCheck">EqualSize</label>
+      <input type="checkbox" id="equalCheck" checked />
     </header>
     <main id="canvas-container">
       <canvas id="gl1"></canvas>
@@ -107,11 +121,17 @@
         nv1.meshes[0].dpv[0].cal_min = this.value * 1; //*1 converts string to number
         nv1.setMeshProperty(nv1.meshes[0].id, "colormap", fiberColormap.value);
       };
-      about.onclick = function () {
-        window.alert(
-          "The `Per Vertex` colors visualize a tsf format overlay created with tcksample",
-        );
-      };
+      layoutSelect.onchange = function () {
+        nv1.setMultiplanarLayout(Number(this.value));
+      }
+      renderingSelect.onchange = function () {
+        nv1.opts.multiplanarShowRender =  Number(this.value);
+        nv1.drawScene();
+      }
+      equalCheck.onchange = function () {
+        nv1.opts.multiplanarEqualSize = this.checked
+        nv1.drawScene()
+      }
       var volumeList1 = [{ url: "../demos/images/mni152.nii.gz" }];
       let defaults = {
         backColor: [0, 0, 0, 1],
@@ -152,6 +172,7 @@
         };
         cmapEl.appendChild(btn);
       }
+      equalCheck.onchange()
     </script>
   </body>
 </html>

--- a/src/nvdocument.ts
+++ b/src/nvdocument.ts
@@ -96,6 +96,7 @@ export type NVConfigOptions = {
   multiplanarPadPixels: number
   // @deprecated
   multiplanarForceRender: boolean
+  multiplanarEqualSize: boolean
   multiplanarShowRender: SHOW_RENDER
   isRadiologicalConvention: boolean
   // string to allow infinity
@@ -177,6 +178,7 @@ export const DEFAULT_OPTIONS: NVConfigOptions = {
   multiplanarPadPixels: 0,
   // @deprecated
   multiplanarForceRender: false,
+  multiplanarEqualSize: false,
   multiplanarShowRender: SHOW_RENDER.AUTO, // auto is the same behaviour as multiplanarForceRender: false
   isRadiologicalConvention: false,
   meshThicknessOn2D: Infinity,

--- a/src/nvmesh-loaders.ts
+++ b/src/nvmesh-loaders.ts
@@ -915,7 +915,7 @@ export class NVMeshLoaders {
           layer.values = obj
         }
       }
-    } else if (ext === 'CRV' || ext === 'CURV') {
+    } else if (ext === 'CRV' || ext === 'CURV' || ext === 'THICKNESS' || ext === 'AREA') {
       layer.values = NVMeshLoaders.readCURV(buffer, n_vert)
       layer.isTransparentBelowCalMin = false
     } else if (ext === 'GII') {
@@ -941,6 +941,10 @@ export class NVMeshLoaders {
       layer.values = NVMeshLoaders.readSMP(buffer, n_vert)
     } else if (ext === 'STC') {
       layer.values = NVMeshLoaders.readSTC(buffer, n_vert)
+    } else if (NVMeshLoaders.isCurv(buffer)) {
+      // Unknown layer overlay format - hail mary assume FreeSurfer
+      layer.values = NVMeshLoaders.readCURV(buffer, n_vert)
+      layer.isTransparentBelowCalMin = false
     } else {
       log.warn('Unknown layer overlay format ' + name)
       return layer
@@ -1128,6 +1132,19 @@ export class NVMeshLoaders {
     }
     return f32
   } // readSTC()
+
+  static isCurv(buffer: ArrayBuffer): boolean {
+    const view = new DataView(buffer) // ArrayBuffer to dataview
+    // ALWAYS big endian
+    const sig0 = view.getUint8(0)
+    const sig1 = view.getUint8(1)
+    const sig2 = view.getUint8(2)
+    if (sig0 !== 255 || sig1 !== 255 || sig2 !== 255) {
+      utiltiesLogger.debug('Unable to recognize file type: does not appear to be FreeSurfer format.')
+      return false
+    }
+    return true
+  }
 
   // read freesurfer curv big-endian format
   // https://github.com/bonilhamusclab/MRIcroS/blob/master/%2BfileUtils/%2Bpial/readPial.m


### PR DESCRIPTION
List of fixed issues (if they exist):

- #1054 
- #1056 

Note that the `npm run dev` live demo now includes a checkbox to interactively set opts.multiplanarEqualSize

The figure below shows a few key features:
 - The same zoom scale is used for all images. In the image below, the coronal scan does not grow to the constraints of the height or width, rather the zoom is constrained by other views. 
 - The orientation labels stay close to the image. In the image below, the `S` letters are just above the image, not at the top of an equally sized tile. Likewise, the `L` letters stick close to the image they refer to.
![equal](https://github.com/user-attachments/assets/b084f301-1bcd-419d-8ff2-10116c75ed4f)
