### PR TITLE
implement click to segment cursor

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -116,7 +116,8 @@
       let defaults = {
         backColor: [0, 0, 0, 1],
         show3Dcrosshair: true,
-        loglevel: 'debug'
+        loglevel: 'debug',
+        isRuler: true
       };
       var nv1 = new Niivue(defaults);
       nv1.attachToCanvas(gl1);

--- a/src/niivue/index.ts
+++ b/src/niivue/index.ts
@@ -7249,7 +7249,10 @@ export class Niivue {
         this.scene.crosshairPos = vec3.clone(texFrac)
       }
       if (this.opts.drawingEnabled) {
+        // drawing done in voxels
         const pt = this.frac2vox(this.scene.crosshairPos) as [number, number, number]
+        // radius given in mm
+        const ptMM = this.frac2mm(this.scene.crosshairPos)
         // if click-to-segment enabled
         if (this.opts.clickToSegment) {
           const radius = this.opts.clickToSegmentRadius
@@ -7259,11 +7262,15 @@ export class Niivue {
           this.drawPenAxCorSag = axCorSag
           for (let i = 1; i <= steps; i++) {
             const angle = (i / steps) * 2 * Math.PI
-            let xVox = pt[0] + radius * Math.cos(angle)
-            let yVox = pt[1] + radius * Math.sin(angle)
-            const zVox = pt[2]
-            xVox = Math.round(xVox)
-            yVox = Math.round(yVox)
+            // get the x,y,z in mm since radius given in mm
+            const xMM = ptMM[0] + radius * Math.cos(angle)
+            const yMM = ptMM[1] + radius * Math.sin(angle)
+            const zMM = ptMM[2]
+            // convert x,y,z in mm to voxels for drawing
+            const xVox = this.back.mm2vox([xMM, yMM, zMM])[0]
+            const yVox = this.back.mm2vox([xMM, yMM, zMM])[1]
+            const zVox = this.back.mm2vox([xMM, yMM, zMM])[2]
+            // draw the point
             this.drawPt(xVox, yVox, zVox, this.opts.penValue)
             this.drawPenFillPts.push([xVox, yVox, pt[2]])
             // fill in the circle if we are at the last step.


### PR DESCRIPTION
This PR adds a cursor circle when `clickToSegment` is `true` and the user is hovering over a 2D tile. Cursor size is determined by `clickToSegmentRadius` which is specified in millimeters. 

List of fixed issues (if they exist):

- closes #1023 
