### PR TITLE
add options for measure tool display behaviour

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -216,6 +216,7 @@
         measureTextJustify: 'start',
         showMeasureUnits: true,
         measureTextColor: [0, 1, 0, 1],
+        measureLineColor: [1, 0, 0, 1],
         measureTextHeight: 0.04
       };
       var nv1 = new Niivue(defaults);

--- a/src/index.html
+++ b/src/index.html
@@ -97,7 +97,8 @@
         NVImage,
         NVMesh,
         NVMeshLoaders,
-        SHOW_RENDER
+        SHOW_RENDER,
+        DRAG_MODE
       } from "./niivue/index.ts";
       async function addVolumeFromFiles(f) {
         console.log("attempting to open ", f[0].name);
@@ -152,11 +153,70 @@
         nv1.setSliceType(st)
       }
       var volumeList1 = [{ url: "../demos/images/mni152.nii.gz" }];
+
+      // with roiSelect, show the stats from the ROI in a temporary div
+      const onDragRelease = (data) => {
+        // if there is a div with the id dragReleaseDiv, remove it
+        const divToRemove = document.getElementById("dragReleaseDiv");
+        if (divToRemove) {
+          divToRemove.remove();
+        }
+
+        console.log("drag release", data);
+        let obj = nv1.getDescriptives({
+          layer: 0,
+          startVox: data.voxStart,
+          endVox: data.voxEnd,
+          roiIsMask: true,
+        });
+        console.log(obj);
+        // get dpr
+        const dpr = window.devicePixelRatio;
+        // get mouse x,y. Divide by dpr to get the correct position
+        const x = nv1.uiData.dragEnd[0] / dpr;
+        const y = nv1.uiData.dragEnd[1] / dpr;
+        console.log(x, y);
+        const pad = 1;
+        const div = document.createElement("div");
+        // set id for removal on the next pass
+        div.id = "dragReleaseDiv";
+        div.style.color = "red";
+        div.style.position = "absolute";
+        div.style.backgroundColor = "black";
+        div.style.opacity = 0.8;
+        div.style.padding = "5px";
+        // set z-index to be well above the canvas
+        div.style.zIndex = 1000;
+        div.innerHTML = `Mean: ${obj.mean}<br>Area: ${obj.area}<br>Stdev: ${obj.stdev}`;
+        // set position to be at the mouse x,y relative to the canvas
+        div.style.left = x + pad + "px";
+        div.style.top = y + pad + "px";
+        // get the canvas element reference from niivue
+        const canvas = nv1.gl.canvas;
+        // niivue should always be in a container, so get the parent of the canvas
+        const parentDiv = canvas.parentElement;
+        parentDiv.appendChild(div);
+      };
+
+      const onLocationChange = (data) => {
+        // remove the stats div if it exists when the user clicks away 
+        const divToRemove = document.getElementById("dragReleaseDiv");
+        if (divToRemove) {
+          divToRemove.remove();
+        }
+      };
       let defaults = {
         backColor: [0, 0, 0, 1],
         show3Dcrosshair: true,
         loglevel: 'debug',
-        isRuler: true
+        isRuler: true,
+        dragMode: DRAG_MODE.measurement,
+        // onDragRelease: onDragRelease,
+        onLocationChange: onLocationChange,
+        measureTextJustify: 'start',
+        showMeasureUnits: true,
+        measureTextColor: [0, 1, 0, 1],
+        measureTextHeight: 0.04
       };
       var nv1 = new Niivue(defaults);
       nv1.attachToCanvas(gl1);

--- a/src/niivue/index.ts
+++ b/src/niivue/index.ts
@@ -8201,6 +8201,31 @@ export class Niivue {
   // not included in public docs
   // draw line between start/end points and text to report length
   drawMeasurementTool(startXYendXY: number[]): void {
+    function extendTo(
+      x0: number,
+      y0: number,
+      x1: number,
+      y1: number,
+      distance: number
+    ): { origin: number[]; terminus: number[] } {
+      const x = x0 - x1
+      const y = y0 - y1
+      if (x === 0 && y === 0) {
+        return {
+          origin: [x1 + distance, y1],
+          terminus: [x1 + distance, y1]
+        }
+      }
+      const c = Math.sqrt(x * x + y * y)
+      const dX = (distance * x) / c
+      const dY = (distance * y) / c
+      return {
+        origin: [x0 + dX, y0 + dY], // next to start point
+        terminus: [x1 - dX, y1 - dY]
+      }
+      // return [x1 - dX, y1 - dY];  // next to end point
+    }
+
     const gl = this.gl
     gl.bindVertexArray(this.genericVAO)
 
@@ -8250,8 +8275,25 @@ export class Niivue {
       if (lenMM > 99) {
         decimals = 0
       }
-      const stringMM = lenMM.toFixed(decimals)
-      this.drawTextBetween(startXYendXY, stringMM, 1, color)
+      let stringMM = lenMM.toFixed(decimals)
+      if (this.opts.showMeasureUnits) {
+        stringMM = `${stringMM} mm` // append mm for millimeters to show units
+      }
+      let textCoords = startXYendXY
+      const [x0, y0, x1, y1] = startXYendXY
+      const { origin, terminus } = extendTo(x0, y0, x1, y1, 30)
+      switch (this.opts.measureTextJustify) {
+        case 'start':
+          textCoords = [...origin, ...origin.map((point) => point + 1)]
+          break
+        case 'end':
+          textCoords = textCoords = [...terminus, ...terminus.map((point) => point + 1)]
+          break
+        default:
+          textCoords = startXYendXY
+          break
+      }
+      this.drawTextBetween(textCoords, stringMM, this.opts.measureTextHeight / this.opts.textHeight, color)
     }
     gl.bindVertexArray(this.unusedVAO) // set vertex attributes
   }
@@ -8731,15 +8773,16 @@ export class Niivue {
     const LTWH = [xy[0] - 1, xy[1] - 1, w + 2, size + 2]
     let clr = color
     if (clr === null) {
-      clr = this.opts.crosshairColor
+      clr = this.opts.measureTextColor
     }
+    // if color is bright, make rect background dark and vice versa
     if (clr && clr[0] + clr[1] + clr[2] > 0.8) {
       clr = [0, 0, 0, 0.5]
     } else {
       clr = [1, 1, 1, 0.5]
     }
-    this.drawRect(LTWH, clr)
-    this.drawText(xy, str, scale, color)
+    this.drawRect(LTWH, clr) // background rect
+    this.drawText(xy, str, scale, color) // the text
   }
 
   // not included in public docs

--- a/src/niivue/index.ts
+++ b/src/niivue/index.ts
@@ -8245,9 +8245,9 @@ export class Niivue {
     gl.uniform4fv(this.lineShader.uniforms.startXYendXY, startXYendXY)
     gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4)
     // draw startCap
-    const color = this.opts.rulerColor
-    color[3] = 1.0 // opaque
-    gl.uniform4fv(this.lineShader.uniforms.lineColor, color)
+    const measureLineColor = this.opts.measureLineColor
+    measureLineColor[3] = 1.0 // opaque
+    gl.uniform4fv(this.lineShader.uniforms.lineColor, measureLineColor)
     const w = this.opts.rulerWidth
     gl.uniform1f(this.lineShader.uniforms.thickness, w * 2)
     let sXYeXY = [startXYendXY[0], startXYendXY[1] - w, startXYendXY[0], startXYendXY[1] + w]
@@ -8293,7 +8293,12 @@ export class Niivue {
           textCoords = startXYendXY
           break
       }
-      this.drawTextBetween(textCoords, stringMM, this.opts.measureTextHeight / this.opts.textHeight, color)
+      this.drawTextBetween(
+        textCoords,
+        stringMM,
+        this.opts.measureTextHeight / this.opts.textHeight,
+        this.opts.measureTextColor
+      )
     }
     gl.bindVertexArray(this.unusedVAO) // set vertex attributes
   }
@@ -8773,7 +8778,7 @@ export class Niivue {
     const LTWH = [xy[0] - 1, xy[1] - 1, w + 2, size + 2]
     let clr = color
     if (clr === null) {
-      clr = this.opts.measureTextColor
+      clr = this.opts.crosshairColor
     }
     // if color is bright, make rect background dark and vice versa
     if (clr && clr[0] + clr[1] + clr[2] > 0.8) {

--- a/src/nvdocument.ts
+++ b/src/nvdocument.ts
@@ -159,6 +159,7 @@ export type NVConfigOptions = {
   // measureTextJustify: "origin" | "terminus" | "center"
   measureTextJustify: 'start' | 'center' | 'end' // similar to flexbox justify start, end, center
   measureTextColor: number[]
+  measureLineColor: number[]
   measureTextHeight: number
 }
 
@@ -248,6 +249,7 @@ export const DEFAULT_OPTIONS: NVConfigOptions = {
   showMeasureUnits: true, // e.g. 20.2 vs 20.2 mm
   measureTextJustify: 'center', // start, center, end
   measureTextColor: [1, 0, 0, 1], // red
+  measureLineColor: [1, 0, 0, 1], // red
   measureTextHeight: 0.03
 }
 

--- a/src/nvdocument.ts
+++ b/src/nvdocument.ts
@@ -155,6 +155,11 @@ export type NVConfigOptions = {
   selectionBoxLineThickness: number
   selectionBoxIsOutline: boolean
   scrollRequiresFocus: boolean
+  showMeasureUnits: boolean
+  // measureTextJustify: "origin" | "terminus" | "center"
+  measureTextJustify: 'start' | 'center' | 'end' // similar to flexbox justify start, end, center
+  measureTextColor: number[]
+  measureTextHeight: number
 }
 
 export const DEFAULT_OPTIONS: NVConfigOptions = {
@@ -239,7 +244,11 @@ export const DEFAULT_OPTIONS: NVConfigOptions = {
   clickToSegmentIs2D: false,
   selectionBoxLineThickness: 4,
   selectionBoxIsOutline: false,
-  scrollRequiresFocus: false // determines if the cavas need to be focused to scroll
+  scrollRequiresFocus: false, // determines if the cavas need to be focused to scroll
+  showMeasureUnits: true, // e.g. 20.2 vs 20.2 mm
+  measureTextJustify: 'center', // start, center, end
+  measureTextColor: [1, 0, 0, 1], // red
+  measureTextHeight: 0.03
 }
 
 type SceneData = {


### PR DESCRIPTION
This PR adds the following options for the measurement tool

- `measureTextJustify: 'start'` (similar to css flexbox -- e.g. start, center, end)
- `showMeasureUnits: true` (20.2 vs 20.2 mm)
- `measureTextColor: [0, 1, 0, 1]` (the color of the text)
- `measureLineColor: [1, 0, 0, 1]` (the color of the line drawn by the tool)
- `measureTextHeight: 0.04` (fractional height, separate from main textHeight property for orientation labels)

@jennydaman , I have added you as a co-author to this commit since the implementation uses your code referenced in issue #1090. Feel free to edit as needed. 

You can run `npm run dev` on this branch to see a demonstration (use right click + drag on the canvas). 

List of fixed issues (if they exist):

- #1090 

