### PR TITLE
set parent div background color to opts.backColor

### DIFF
--- a/src/niivue/index.ts
+++ b/src/niivue/index.ts
@@ -912,9 +912,11 @@ export class Niivue {
 
     log.info('NIIVUE VERSION ', version)
 
-    // set parent background container to black (default empty canvas color)
-    // avoids white cube around image in 3D render mode
-    this.canvas!.parentElement!.style.backgroundColor = 'black'
+    let [r, g, b, a] = this.opts.backColor
+    r = Math.round(r * 255)
+    g = Math.round(g * 255)
+    b = Math.round(b * 255)
+    this.canvas!.parentElement!.style.backgroundColor = `rgba(${r}, ${g}, ${b}, ${a})`
     // fill all space in parent
     if (this.opts.isResizeCanvas) {
       this.canvas.style.width = '100%'


### PR DESCRIPTION
This PR changes how we set the canvas parent background color. We set it to black by default previously, but I think it makes more sense to set the canvas's parent background color to the same color specified in `opts.backColor`. This way, a div with padding around the canvas wont show a black border behind the canvas. 
