### PR TITLE
implement new drag mode for adjusting window and level

### DIFF
--- a/packages/niivue/src/index.html
+++ b/packages/niivue/src/index.html
@@ -15,31 +15,15 @@
     <header>
       <button id="openBtn">Choose an image or mesh with a dialog</button>
       <label for="fiberRadius">Radius</label>
-      <input
-        type="range"
-        min="0"
-        max="20"
-        value="5"
-        class="slider"
-        id="fiberRadius"
-      />
+      <input type="range" min="0" max="20" value="5" class="slider" id="fiberRadius" />
       <label for="fiberDitherSlider">Dither</label>
-      <input
-        type="range"
-        min="0"
-        max="10"
-        value="0"
-        class="slider"
-        id="fiberDitherSlider"
-      />
+      <input type="range" min="0" max="10" value="0" class="slider" id="fiberDitherSlider" />
       <label for="fiberColor">Fiber color</label>
       <select id="fiberColor">
         <option value="Global">Global direction</option>
         <option value="Local">Local direction</option>
         <option value="Fixed">Fixed</option>
-        <option value="DPV0" selected>
-          First Per Vertex Type (if available)
-        </option>
+        <option value="DPV0" selected>First Per Vertex Type (if available)</option>
       </select>
       <label for="fiberColormap">Colormap</label>
       <select id="fiberColormap">
@@ -50,14 +34,7 @@
         <option value="winter">Winter</option>
       </select>
       <label for="fiberCalMin">Color Minimum</label>
-      <input
-        type="range"
-        min="10"
-        max="75"
-        value="25"
-        class="slider"
-        id="fiberCalMin"
-      />
+      <input type="range" min="10" max="75" value="25" class="slider" id="fiberCalMin" />
       <label for="layoutSelect">Layout</label>
       <select id="layoutSelect">
         <option value="0" selected>Auto</option>
@@ -85,17 +62,10 @@
       <label for="marginCheck">TileMargin</label>
       <input type="checkbox" id="marginCheck" unchecked />
       <label for="heroSlider">Hero Image</label>
-      <input
-        type="range"
-        min="0"
-        max="9"
-        value="0"
-        class="slider"
-        id="heroSlider"
-      />
+      <input type="range" min="0" max="9" value="0" class="slider" id="heroSlider" />
     </header>
     <main id="canvas-container">
-      <div style="display: flex; width: 100%; height: 100%;">
+      <div style="display: flex; width: 100%; height: 100%">
         <canvas id="gl1"></canvas>
       </div>
     </main>
@@ -109,54 +79,55 @@
         NVMesh,
         NVMeshLoaders,
         SHOW_RENDER,
-        DRAG_MODE
-      } from "./niivue/index.ts";
+        DRAG_MODE,
+        DRAG_MODE_PRIMARY
+      } from './niivue/index.ts'
       async function addVolumeFromFiles(f) {
-        console.log("attempting to open ", f[0].name);
-        console.log("details", f[0]);
-        nv1.loadFromFile(f[0]);
+        console.log('attempting to open ', f[0].name)
+        console.log('details', f[0])
+        nv1.loadFromFile(f[0])
       }
       openBtn.onclick = function () {
-        let input = document.createElement("input");
-        input.style.display = "none";
-        input.type = "file";
-        document.body.appendChild(input);
+        let input = document.createElement('input')
+        input.style.display = 'none'
+        input.type = 'file'
+        document.body.appendChild(input)
         input.onchange = function (event) {
-          addVolumeFromFiles(event.target.files);
-        };
-        input.click();
-      };
+          addVolumeFromFiles(event.target.files)
+        }
+        input.click()
+      }
       fiberRadius.oninput = function () {
-        nv1.setMeshProperty(nv1.meshes[0].id, "fiberRadius", this.value * 0.1);
-        nv1.updateGLVolume();
-      };
+        nv1.setMeshProperty(nv1.meshes[0].id, 'fiberRadius', this.value * 0.1)
+        nv1.updateGLVolume()
+      }
       fiberColor.onchange = function () {
-        nv1.setMeshProperty(nv1.meshes[0].id, "fiberColor", this.value);
-      };
+        nv1.setMeshProperty(nv1.meshes[0].id, 'fiberColor', this.value)
+      }
       fiberColormap.onchange = function () {
-        nv1.setMeshProperty(nv1.meshes[0].id, "colormap", this.value);
-      };
+        nv1.setMeshProperty(nv1.meshes[0].id, 'colormap', this.value)
+      }
 
       fiberDitherSlider.oninput = function () {
-        nv1.setMeshProperty(nv1.meshes[0].id, "fiberDither", this.value * 0.1);
-      };
+        nv1.setMeshProperty(nv1.meshes[0].id, 'fiberDither', this.value * 0.1)
+      }
       fiberCalMin.oninput = function () {
-        nv1.meshes[0].dpv[0].cal_min = this.value * 1; //*1 converts string to number
-        nv1.setMeshProperty(nv1.meshes[0].id, "colormap", fiberColormap.value);
-      };
+        nv1.meshes[0].dpv[0].cal_min = this.value * 1 //*1 converts string to number
+        nv1.setMeshProperty(nv1.meshes[0].id, 'colormap', fiberColormap.value)
+      }
       layoutSelect.onchange = function () {
-        nv1.setMultiplanarLayout(Number(this.value));
+        nv1.setMultiplanarLayout(Number(this.value))
       }
       renderingSelect.onchange = function () {
-        nv1.opts.multiplanarShowRender =  Number(this.value);
-        nv1.drawScene();
+        nv1.opts.multiplanarShowRender = Number(this.value)
+        nv1.drawScene()
       }
       equalCheck.onchange = function () {
         nv1.opts.multiplanarEqualSize = this.checked
         nv1.drawScene()
       }
       marginCheck.onchange = function () {
-        nv1.opts.tileMargin = this.checked  ? -1 : 0
+        nv1.opts.tileMargin = this.checked ? -1 : 0
         nv1.drawScene()
       }
       cornerCheck.onchange = function () {
@@ -167,62 +138,62 @@
         nv1.setHeroImage(this.value * 0.1)
       }
       sliceType.onchange = function () {
-        let st = parseInt(document.getElementById("sliceType").value);
+        let st = parseInt(document.getElementById('sliceType').value)
         nv1.setSliceType(st)
       }
-      var volumeList1 = [{ url: "../demos/images/mni152.nii.gz" }];
+      var volumeList1 = [{ url: '../demos/images/mni152.nii.gz' }]
 
       // with roiSelect, show the stats from the ROI in a temporary div
       const onDragRelease = (data) => {
         // if there is a div with the id dragReleaseDiv, remove it
-        const divToRemove = document.getElementById("dragReleaseDiv");
+        const divToRemove = document.getElementById('dragReleaseDiv')
         if (divToRemove) {
-          divToRemove.remove();
+          divToRemove.remove()
         }
 
-        console.log("drag release", data);
+        console.log('drag release', data)
         let obj = nv1.getDescriptives({
           layer: 0,
           startVox: data.voxStart,
           endVox: data.voxEnd,
-          roiIsMask: true,
-        });
-        console.log(obj);
+          roiIsMask: true
+        })
+        console.log(obj)
         // get dpr
-        const dpr = window.devicePixelRatio;
+        const dpr = window.devicePixelRatio
         // get mouse x,y. Divide by dpr to get the correct position
-        const x = nv1.uiData.dragEnd[0] / dpr;
-        const y = nv1.uiData.dragEnd[1] / dpr;
-        console.log(x, y);
-        const pad = 1;
-        const div = document.createElement("div");
+        const x = nv1.uiData.dragEnd[0] / dpr
+        const y = nv1.uiData.dragEnd[1] / dpr
+        console.log(x, y)
+        const pad = 1
+        const div = document.createElement('div')
         // set id for removal on the next pass
-        div.id = "dragReleaseDiv";
-        div.style.color = "red";
-        div.style.position = "absolute";
-        div.style.backgroundColor = "black";
-        div.style.opacity = 0.8;
-        div.style.padding = "5px";
+        div.id = 'dragReleaseDiv'
+        div.style.color = 'red'
+        div.style.position = 'absolute'
+        div.style.backgroundColor = 'black'
+        div.style.opacity = 0.8
+        div.style.padding = '5px'
         // set z-index to be well above the canvas
-        div.style.zIndex = 1000;
-        div.innerHTML = `Mean: ${obj.mean}<br>Area: ${obj.area}<br>Stdev: ${obj.stdev}`;
+        div.style.zIndex = 1000
+        div.innerHTML = `Mean: ${obj.mean}<br>Area: ${obj.area}<br>Stdev: ${obj.stdev}`
         // set position to be at the mouse x,y relative to the canvas
-        div.style.left = x + pad + "px";
-        div.style.top = y + pad + "px";
+        div.style.left = x + pad + 'px'
+        div.style.top = y + pad + 'px'
         // get the canvas element reference from niivue
-        const canvas = nv1.gl.canvas;
+        const canvas = nv1.gl.canvas
         // niivue should always be in a container, so get the parent of the canvas
-        const parentDiv = canvas.parentElement;
-        parentDiv.appendChild(div);
-      };
+        const parentDiv = canvas.parentElement
+        parentDiv.appendChild(div)
+      }
 
       const onLocationChange = (data) => {
-        // remove the stats div if it exists when the user clicks away 
-        const divToRemove = document.getElementById("dragReleaseDiv");
+        // remove the stats div if it exists when the user clicks away
+        const divToRemove = document.getElementById('dragReleaseDiv')
         if (divToRemove) {
-          divToRemove.remove();
+          divToRemove.remove()
         }
-      };
+      }
       let defaults = {
         backColor: [0, 0.2, 0.4, 1],
         show3Dcrosshair: true,
@@ -235,43 +206,39 @@
         showMeasureUnits: true,
         measureTextColor: [0, 1, 0, 1],
         measureLineColor: [1, 0, 0, 1],
-        measureTextHeight: 0.04
-      };
-      var nv1 = new Niivue(defaults);
-      nv1.attachToCanvas(gl1);
-      // multiplanarShowRender is the preferred option now, 
+        measureTextHeight: 0.04,
+        dragModePrimary: DRAG_MODE_PRIMARY.windowing
+      }
+      var nv1 = new Niivue(defaults)
+      nv1.attachToCanvas(gl1)
+      // multiplanarShowRender is the preferred option now,
       // but multiplanarForceRender is still available for backwards compatibility
       // previous use was: nv1.opts.multiplanarForceRender = true;
       nv1.opts.multiplanarShowRender = SHOW_RENDER.AUTO
-      nv1.opts.yoke3Dto2DZoom = true;
-      await nv1.loadVolumes(volumeList1);
-      var layerList = [{ url: "../demos/images/mni152.SLF1_R.tsf" }];
-      await nv1.loadMeshes([
-        { url: "../demos/images/tract.SLF1_R.tck", layers: layerList },
-      ]);
-      nv1.setMeshProperty(nv1.meshes[0].id, "fiberColor", "DPV0");
-      nv1.setMeshProperty(nv1.meshes[0].id, "fiberDither", 0);
-      nv1.setMeshProperty(nv1.meshes[0].id, "fiberRadius", 0.5);
-      nv1.setMeshProperty(nv1.meshes[0].id, "rgba255", [0, 255, 255, 255]); //color for fixed
-      nv1.setMeshShader(nv1.meshes[0].id, "diffuse");
-      console.log(
-        "fiber vertex intensity range:",
-        nv1.meshes[0].dpv[0].global_min,
-        nv1.meshes[0].dpv[0].global_max,
-      );
-      nv1.setSelectionBoxColor([0, 1, 0, 0.5]);
-      nv1.setClipPlane([0.2, 0, 120]);
-      let cmaps = nv1.meshShaderNames();
-      let cmapEl = document.getElementById("shaders");
+      nv1.opts.yoke3Dto2DZoom = true
+      await nv1.loadVolumes(volumeList1)
+      var layerList = [{ url: '../demos/images/mni152.SLF1_R.tsf' }]
+      await nv1.loadMeshes([{ url: '../demos/images/tract.SLF1_R.tck', layers: layerList }])
+      nv1.setMeshProperty(nv1.meshes[0].id, 'fiberColor', 'DPV0')
+      nv1.setMeshProperty(nv1.meshes[0].id, 'fiberDither', 0)
+      nv1.setMeshProperty(nv1.meshes[0].id, 'fiberRadius', 0.5)
+      nv1.setMeshProperty(nv1.meshes[0].id, 'rgba255', [0, 255, 255, 255]) //color for fixed
+      nv1.setMeshShader(nv1.meshes[0].id, 'diffuse')
+      console.log('fiber vertex intensity range:', nv1.meshes[0].dpv[0].global_min, nv1.meshes[0].dpv[0].global_max)
+      nv1.setSelectionBoxColor([0, 1, 0, 0.5])
+      nv1.setClipPlane([0.2, 0, 120])
+      let cmaps = nv1.meshShaderNames()
+      let cmapEl = document.getElementById('shaders')
       for (let i = 0; i < cmaps.length; i++) {
-        let btn = document.createElement("button");
-        btn.innerHTML = cmaps[i];
+        let btn = document.createElement('button')
+        btn.innerHTML = cmaps[i]
         btn.onclick = function () {
-          nv1.setMeshShader(nv1.meshes[0].id, cmaps[i]);
-        };
-        cmapEl.appendChild(btn);
+          nv1.setMeshShader(nv1.meshes[0].id, cmaps[i])
+        }
+        cmapEl.appendChild(btn)
       }
       equalCheck.onchange()
     </script>
   </body>
 </html>
+

--- a/packages/niivue/src/niivue/index.ts
+++ b/packages/niivue/src/niivue/index.ts
@@ -1647,7 +1647,6 @@ export class Niivue {
     const valmin = this.volumes[volIdx].cal_min
     const valmax = this.volumes[volIdx].cal_max
     const level = (valmax - valmin) / 2 + valmin
-    console.log(valmin, level, valmax)
     this.refreshLayers(this.volumes[volIdx], 0)
     // set the current mouse position (window space) as the new reference point
     // for the next comparison

--- a/packages/niivue/src/niivue/index.ts
+++ b/packages/niivue/src/niivue/index.ts
@@ -73,7 +73,8 @@ import {
   Scene,
   SLICE_TYPE,
   SHOW_RENDER,
-  DRAG_MODE,
+  DRAG_MODE, // DRAG_MODE_SECONDARY is the same as DRAG_MODE. DRAG_MODE may be deprecated.
+  DRAG_MODE_PRIMARY,
   COLORMAP_TYPE,
   MULTIPLANAR_TYPE,
   DEFAULT_OPTIONS,
@@ -305,6 +306,8 @@ type UIData = {
   lastTwoTouchDistance: number
   multiTouchGesture: boolean
   dpr?: number
+  windowX: number // used to track mouse position for DRAG_MODE_PRIMARY.windowing
+  windowY: number // used to track mouse position for DRAG_MODE_PRIMARY.windowing
 }
 
 type SaveImageOptions = {
@@ -459,7 +462,9 @@ export class Niivue {
     dragEnd: [0.0, 0.0],
     dragClipPlaneStartDepthAziElev: [0, 0, 0],
     lastTwoTouchDistance: 0,
-    multiTouchGesture: false
+    multiTouchGesture: false,
+    windowX: 0,
+    windowY: 0
   }
 
   back: NVImage | null = null // base layer; defines image space to work in. Defined as this.volumes[0] in Niivue.loadVolumes
@@ -1281,9 +1286,16 @@ export class Niivue {
   // handler for mouse left button down
   // note: no test yet
   mouseLeftButtonHandler(e: MouseEvent): void {
-    const pos = this.getNoPaddingNoBorderCanvasRelativeMousePosition(e, this.gl.canvas)
-    this.mouseDown(pos!.x, pos!.y)
-    this.mouseClick(pos!.x, pos!.y)
+    // need to check for control key here in case the user want to override the drag mode
+    if (e.ctrlKey || this.opts.dragModePrimary === DRAG_MODE_PRIMARY.crosshair) {
+      const pos = this.getNoPaddingNoBorderCanvasRelativeMousePosition(e, this.gl.canvas)
+      this.mouseDown(pos!.x, pos!.y)
+      this.mouseClick(pos!.x, pos!.y)
+    } else if (this.opts.dragModePrimary === DRAG_MODE_PRIMARY.windowing) {
+      // save the state of the x and y mouse coordinates for the next comparison on mouse move
+      this.uiData.windowX = e.x
+      this.uiData.windowY = e.y
+    }
   }
 
   // not included in public docs
@@ -1581,6 +1593,68 @@ export class Niivue {
     this.mouseUpListener()
   }
 
+  windowingHandler(x: number, y: number, volIdx: number = 0): void {
+    // x and y are the current mouse or touch position in window coordinates
+    const wx = this.uiData.windowX
+    const wy = this.uiData.windowY
+    let mn = this.volumes[0].cal_min
+    let mx = this.volumes[0].cal_max
+    const gmn = this.volumes[0].global_min
+    const gmx = this.volumes[0].global_max
+
+    if (y < wy) {
+      // increase level if mouse moves up
+      mn += 1
+      mx += 1
+    } else if (y > wy) {
+      // decrease level if mouse moves down
+      mn -= 1
+      mx -= 1
+    }
+
+    if (x > wx) {
+      // increase window width if mouse moves right
+      mn -= 1
+      mx += 1
+    } else if (x < wx) {
+      // decrease window width if mouse moves left
+      mn += 1
+      mx -= 1
+    }
+
+    if (mx - mn < 1) {
+      // ensure window width is at least 1
+      mx = mn + 1
+    }
+
+    if (mn < gmn) {
+      // ensure min is not below global min
+      mn = gmn
+    }
+
+    if (mx > gmx) {
+      // ensure max is not above global max
+      mx = gmx
+    }
+
+    if (mn > mx) {
+      // ensure min is not above max
+      mn = mx - 1
+    }
+
+    this.volumes[volIdx].cal_min = mn
+    this.volumes[volIdx].cal_max = mx
+    const valmin = this.volumes[volIdx].cal_min
+    const valmax = this.volumes[volIdx].cal_max
+    const level = (valmax - valmin) / 2 + valmin
+    console.log(valmin, level, valmax)
+    this.refreshLayers(this.volumes[volIdx], 0)
+    // set the current mouse position (window space) as the new reference point
+    // for the next comparison
+    this.uiData.windowX = x
+    this.uiData.windowY = y
+  }
+
   // not included in public docs
   // handler for mouse move over canvas
   // note: no test yet
@@ -1600,8 +1674,15 @@ export class Niivue {
         return
       }
       if (this.uiData.mouseButtonLeftDown) {
-        this.mouseMove(pos.x, pos.y)
-        this.mouseClick(pos.x, pos.y)
+        const isCrosshairMode = this.opts.dragModePrimary === DRAG_MODE_PRIMARY.crosshair
+        const isWindowingMode = this.opts.dragModePrimary === DRAG_MODE_PRIMARY.windowing
+        const ctrlKey = e.ctrlKey
+        if (ctrlKey || isCrosshairMode) {
+          this.mouseMove(pos.x, pos.y)
+          this.mouseClick(pos.x, pos.y)
+        } else if (isWindowingMode) {
+          this.windowingHandler(e.x, e.y)
+        }
       } else if (this.uiData.mouseButtonRightDown || this.uiData.mouseButtonCenterDown) {
         this.setDragEnd(pos.x, pos.y)
       }
@@ -1709,8 +1790,15 @@ export class Niivue {
         this.drawScene()
         return
       }
-      this.mouseClick(e.touches[0].clientX - rect.left, e.touches[0].clientY - rect.top)
-      this.mouseMove(e.touches[0].clientX - rect.left, e.touches[0].clientY - rect.top)
+      const isCrosshairMode = this.opts.dragModePrimary === DRAG_MODE_PRIMARY.crosshair
+      const isWindowingMode = this.opts.dragModePrimary === DRAG_MODE_PRIMARY.windowing
+      if (isCrosshairMode) {
+        this.mouseClick(e.touches[0].clientX - rect.left, e.touches[0].clientY - rect.top)
+        this.mouseMove(e.touches[0].clientX - rect.left, e.touches[0].clientY - rect.top)
+      } else if (isWindowingMode) {
+        this.windowingHandler(e.touches[0].pageX, e.touches[0].pageY)
+        this.drawScene()
+      }
     } else {
       // Check this event for 2-touch Move/Pinch/Zoom gesture
       this.handlePinchZoom(e)

--- a/packages/niivue/src/niivue/index.ts
+++ b/packages/niivue/src/niivue/index.ts
@@ -1644,9 +1644,6 @@ export class Niivue {
 
     this.volumes[volIdx].cal_min = mn
     this.volumes[volIdx].cal_max = mx
-    const valmin = this.volumes[volIdx].cal_min
-    const valmax = this.volumes[volIdx].cal_max
-    const level = (valmax - valmin) / 2 + valmin
     this.refreshLayers(this.volumes[volIdx], 0)
     // set the current mouse position (window space) as the new reference point
     // for the next comparison

--- a/packages/niivue/src/nvdocument.ts
+++ b/packages/niivue/src/nvdocument.ts
@@ -50,6 +50,21 @@ export enum DRAG_MODE {
   roiSelection = 6
 }
 
+export enum DRAG_MODE_SECONDARY {
+  none = 0,
+  contrast = 1,
+  measurement = 2,
+  pan = 3,
+  slicer3D = 4,
+  callbackOnly = 5,
+  roiSelection = 6
+}
+
+export enum DRAG_MODE_PRIMARY {
+  crosshair = 0,
+  windowing = 1
+}
+
 export enum COLORMAP_TYPE {
   MIN_TO_MAX = 0,
   ZERO_TO_MAX_TRANSPARENT_BELOW_MIN = 1,
@@ -110,7 +125,8 @@ export type NVConfigOptions = {
   isRadiologicalConvention: boolean
   // string to allow infinity
   meshThicknessOn2D: number | string
-  dragMode: DRAG_MODE
+  dragMode: DRAG_MODE | DRAG_MODE_SECONDARY
+  dragModePrimary: DRAG_MODE_PRIMARY
   yoke3Dto2DZoom: boolean
   isDepthPickMesh: boolean
   isCornerOrientationText: boolean
@@ -212,7 +228,8 @@ export const DEFAULT_OPTIONS: NVConfigOptions = {
   multiplanarShowRender: SHOW_RENDER.AUTO, // auto is the same behaviour as multiplanarForceRender: false
   isRadiologicalConvention: false,
   meshThicknessOn2D: Infinity,
-  dragMode: DRAG_MODE.contrast,
+  dragMode: DRAG_MODE_SECONDARY.contrast,
+  dragModePrimary: DRAG_MODE_PRIMARY.crosshair,
   yoke3Dto2DZoom: false,
   isDepthPickMesh: false,
   isCornerOrientationText: false,


### PR DESCRIPTION
This PR introduces new functionality that allows users to set the "drag mode" of the primary mouse button (the left button) and for single finger touch drags. 

we have a new `DRAG_MODE_PRIMARY` enum with the options:
- `DRAG_MODE_PRIMARY.windowing`
- `DRAG_MODE_PRIMARY.crosshair` (this is the default to preserve existing functionality)

What does the new windowing click and drag movement do?
- click and drag up in the canvas to make things brighter (moves the display range uniformly lower)
- click and drag down to make things darker (moves the display range uniformly higher)
- click and drag left to increase the contrast (makes the display range more narrow)
- click and drag right to decrease the contrast (makes the display range wider)
- These movements also work in volume rendering (3D) mode, allowing for interesting effects

users can set the primary drag mode in the niivue constructor by passing in the option object like this:

```javascript
import { Niivue, DRAG_MODE_PRIMARY} from '@niivue/niivue'

const nv = new Niivue({
  dragModePrimary: DRAG_MODE_PRIMARY.windowing // or crosshair
})
```

If you want to change the drag mode any time after initializing niivue, then you can simply set `nv.opts.dragModePrimary = DRAG_MODE_PRIMARY.crosshair // or .windowing`

If the windowing drag mode is active, the user can override it by holding the `control` key during the click and drag action with the mouse. This allows using the crosshair mode temporarily. 

Lastly, DRAG_MODE in NiiVue refers to the secondary mouse button (right button). A new enum has been made available in NiiVue called DRAG_MODE_SECONDARY that replicates the original DRAG_MODE enum. It would be nice to deprecate DRAG_MODE eventually in favour of the new DRAG_MODE_SECONDARY and DRAG_MODE_PRIMARY enums. 
