### PR TITLE
Use opts.loadingText

### DIFF
--- a/packages/niivue/src/niivue/index.ts
+++ b/packages/niivue/src/niivue/index.ts
@@ -799,7 +799,6 @@ export class Niivue {
   mediaUrlMap: Map<NVImage | NVMesh, string> = new Map()
   initialized = false
   currentDrawUndoBitmap: number
-  loadingText: string
 
   /**
    * @param options  - options object to set modifiable Niivue properties
@@ -832,7 +831,6 @@ export class Niivue {
       this.thumbnailVisible = true
     }
 
-    this.loadingText = this.opts.loadingText
     log.setLogLevel(this.opts.logLevel)
   }
 
@@ -4338,9 +4336,7 @@ export class Niivue {
    * @see {@link https://niivue.github.io/niivue/features/mask.html | live demo usage}
    */
   async loadVolumes(volumeList: ImageFromUrlOptions[]): Promise<this> {
-    this.loadingText = 'loading...'
     this.drawScene()
-    // this.loadingText = this.opts.loadingText
 
     if (this.thumbnailVisible) {
       // defer volume loading until user clicks on canvas with thumbnail image
@@ -4468,7 +4464,6 @@ export class Niivue {
    * @see {@link https://niivue.github.io/niivue/features/meshes.html | live demo usage}
    */
   async loadMeshes(meshList: LoadFromUrlParams[]): Promise<this> {
-    this.loadingText = 'loading...'
     this.drawScene()
 
     if (this.thumbnailVisible) {
@@ -4575,7 +4570,6 @@ export class Niivue {
    * @see {@link https://niivue.github.io/niivue/features/connectome.html | live demo usage}
    */
   loadConnectome(json: Connectome | LegacyConnectome): this {
-    this.loadingText = 'loading...'
     this.drawScene()
     this.meshes = []
     this.gl.clearColor(0.0, 0.0, 0.0, 1.0)
@@ -5769,7 +5763,7 @@ export class Niivue {
 
     await this.loadDefaultFont()
     await this.loadDefaultMatCap()
-    this.drawLoadingText(this.loadingText)
+    this.drawLoadingText(this.opts.loadingText)
   }
 
   // not included in public docs
@@ -9008,6 +9002,9 @@ export class Niivue {
 
   // not included in public docs
   drawLoadingText(text: string): void {
+    if (!text) {
+      return
+    }
     if (!this.canvas) {
       throw new Error('canvas undefined')
     }
@@ -11609,7 +11606,7 @@ export class Niivue {
         }
         return
       }
-      this.drawLoadingText(this.loadingText)
+      this.drawLoadingText(this.opts.loadingText)
       return
     }
     if (this.back === null) {

--- a/packages/niivue/src/nvdocument.ts
+++ b/packages/niivue/src/nvdocument.ts
@@ -242,7 +242,7 @@ export const DEFAULT_OPTIONS: NVConfigOptions = {
   isV1SliceShader: false,
   isHighResolutionCapable: true,
   logLevel: 'info',
-  loadingText: 'waiting for images...',
+  loadingText: 'loading ...',
   isForceMouseClickToVoxelCenters: false,
   dragAndDropEnabled: true,
   drawingEnabled: false,


### PR DESCRIPTION
- Use the loadingText values specificed with opts
- Keep this.opts.loadingText as the state to use
- If loadingText is empty, do not execute the draw
