### PR TITLE
implement loadImages for custom loaders with drag and drop

### DIFF
--- a/packages/niivue/src/niivue/utils.ts
+++ b/packages/niivue/src/niivue/utils.ts
@@ -3,6 +3,40 @@ import { log } from '../logger.js'
 import { NiftiHeader, Volume } from '../types.js'
 import { NVUtilities } from '../nvutilities.js'
 
+export function readFileAsDataURL(input: File | FileSystemFileEntry): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    let filePromise: Promise<File>
+
+    if (input instanceof File) {
+      filePromise = Promise.resolve(input)
+    } else {
+      filePromise = new Promise<File>((resolve, reject) => {
+        input.file(resolve, reject)
+      })
+    }
+
+    filePromise
+      .then((file) => {
+        const reader = new FileReader()
+
+        reader.onload = (): void => {
+          if (typeof reader.result === 'string') {
+            resolve(reader.result)
+          } else {
+            reject(new Error('Expected a string from FileReader.result'))
+          }
+        }
+
+        reader.onerror = (): void => {
+          reject(reader.error ?? new Error('Unknown FileReader error'))
+        }
+
+        reader.readAsDataURL(file)
+      })
+      .catch((err) => reject(err))
+  })
+}
+
 // rotate image to match right-anterior-superior voxel order
 export function img2ras16(volume: Volume): Int16Array {
   // return image oriented to RAS space as int16

--- a/packages/niivue/types.d.ts
+++ b/packages/niivue/types.d.ts
@@ -2,3 +2,18 @@ declare module '*.png'
 declare module '*.svg'
 declare module '*.jpeg'
 declare module '*.jpg'
+
+// used for custom niivue loaders with drag and drop files
+interface FileSystemEntry {
+  isDirectory: boolean
+  isFile: boolean
+  fullPath: string
+  name: string
+}
+
+// used for custom niivue loaders with drag and drop files
+interface FileSystemFileEntry extends FileSystemEntry {
+  isDirectory: false
+  isFile: true
+  file: (callback: (file: File) => void, errorCallback?: (error: DOMException) => void) => void
+}


### PR DESCRIPTION
This PR allows the niivue file drop handler to load images that require custom loaders. Note that the custom loaders must first be added to the list of known file loaders (usually right after initialising a new niivue instance). 

I have tested this with the ds-loader and the vox-loader examples. 

This implementation reuses as much existing niivue code as possible. 

To test on your own system:

- clone niivue
- `npm run build:niivue`
- `cp -r ./packages/niivue/build/* /path/to/your/local/repo/node_modules/@niivue/niivue/build/`
- in your local repo with a custom loader and niivue `npm run dev`. For example, this would work in the [ds-loader](https://github.com/rordenlab/ds-loader) repo. 
