### PR TITLE
fix: remove unused readBMP test code (fixes #1212)

### DIFF
--- a/packages/niivue/src/nvimage/index.ts
+++ b/packages/niivue/src/nvimage/index.ts
@@ -1209,7 +1209,6 @@ export class NVImage {
     hdr.datatypeCode = NiiDataType.DT_RGBA32
     return data.buffer
   }
-
   // not included in public docs
   // read brainvoyager format VMR image
   // https://support.brainvoyager.com/brainvoyager/automation-development/84-file-formats/343-developer-guide-2-6-the-format-of-vmr-files


### PR DESCRIPTION
List of fixed issues (if they exist):

- Fixes #1212 
- The readBMP test code was outdated and unnecessary. Removing it makes the codebase cleaner and easier to maintain.
- Checklist:
 . Code changes tested locally
 . Linked the PR to the correct issue
 . Commit messages follow the project’s conventions
![Screenshot 2025-03-13 124244](https://github.com/user-attachments/assets/2f364990-5174-4a67-8577-f2aa3f4e3224)

