### PR TITLE
Avoid double unclick to undo filled drawing.

### DIFF
--- a/packages/niivue/src/niivue/index.ts
+++ b/packages/niivue/src/niivue/index.ts
@@ -1478,8 +1478,6 @@ export class Niivue {
     this.uiData.mouseButtonLeftDown = false
     if (this.drawPenFillPts.length > 0) {
       this.drawPenFilled()
-      // add the bitmap after the clickToSegment update
-      this.drawAddUndoBitmap()
     } else if (this.drawPenAxCorSag >= 0) {
       if (this.opts.clickToSegment) {
         // copy clickToSegment bitmap to drawBitmap.
@@ -1490,9 +1488,8 @@ export class Niivue {
           this.updateBitmapFromClickToSegment()
         }
       }
-      // add the bitmap after the clickToSegment update
-      this.drawAddUndoBitmap()
     }
+    this.drawAddUndoBitmap()
     this.drawPenLocation = [NaN, NaN, NaN]
     this.drawPenAxCorSag = -1
     if (isFunction(this.onMouseUp)) {
@@ -5492,9 +5489,8 @@ export class Niivue {
         this.drawBitmap[i] = bmp[i]
       }
     }
-
     this.drawPenFillPts = []
-    this.drawAddUndoBitmap()
+    // this.drawAddUndoBitmap()
     this.refreshDrawing(false)
   }
 


### PR DESCRIPTION
List of fixed issues (if they exist):

- Two click for undo of filled drawing
