### PR TITLE
Fix problem, when url is a Uint8Array that is a view of a larger ArrayBuffer

### DIFF
--- a/packages/niivue/src/nvimage/index.ts
+++ b/packages/niivue/src/nvimage/index.ts
@@ -3144,7 +3144,7 @@ export class NVImage {
 
     // Handle input buffer types
     if (url instanceof Uint8Array) {
-      url = url.buffer as ArrayBuffer
+      url = url.slice().buffer as ArrayBuffer
     }
     if (buffer.byteLength > 0) {
       url = buffer


### PR DESCRIPTION
copy Uint8Array before assigning from url - this fixes a problem when the Uint8Array is a view with a different size to the ArrayBuffer

I created this as a PR instead of an issue, since I can point to the code.

The issue came up for me, when I used a Julia package for sending objects to javascript (Bonito.jl). The data sent from julia is a Uint8Array, but the size of the underlying ArrayBuffer is different. This is the error I received:
index.ts:591 Uncaught (in promise) Error: Failed to parse NIfTI file image.nii.
    at _NVImage.new (index.ts:591:17)
    at async _NVImage.loadFromUrl (index.ts:3289:15)
    at async index.ts:2304:22
    at async Promise.all (index 0)
    at async Niivue.addVolumesFromUrl (index.ts:2314:21)
    at async Niivue.loadVolumes (index.ts:4692:5)

The size of my Uint8Array was 282928, while the size of the underlying ArrayBuffer was 283370.

The call to slice() in this PR copies the data into a new ArrayBuffer and solves the issue for me, but I'm not sure if this has other detrimental effects like bad performance.

For now, I copy the data before giving the Uint8Array to niivue, so I don't rely on this PR being merged, but other frameworks might also run into the same problem, if they give a Uint8Array data as a view of a larger ArrayBuffer.