### PR TITLE
Hanayik/histo readers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9298,6 +9298,16 @@
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "license": "Apache-2.0"
         },
+        "node_modules/@zarrita/storage": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.1.1.tgz",
+            "integrity": "sha512-6/NUCvpzsIxfxeMv59jRTl/bOZg3GZfMP6iR8EIqrTaaE0S2jLL/ceX1OxcFBKnuA8/Z2YmgX4SFBHwFGrCcsw==",
+            "license": "MIT",
+            "dependencies": {
+                "reference-spec-reader": "^0.2.0",
+                "unzipit": "^1.4.3"
+            }
+        },
         "node_modules/7zip-bin": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.2.0.tgz",
@@ -20328,6 +20338,15 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
+        "node_modules/numcodecs": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.3.2.tgz",
+            "integrity": "sha512-6YSPnmZgg0P87jnNhi3s+FVLOcIn3y+1CTIgUulA3IdASzK9fJM87sUFkpyA+be9GibGRaST2wCgkD+6U+fWKw==",
+            "license": "MIT",
+            "dependencies": {
+                "fflate": "^0.8.0"
+            }
+        },
         "node_modules/nwsapi": {
             "version": "2.2.18",
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.18.tgz",
@@ -23594,6 +23613,12 @@
                 "node": "*"
             }
         },
+        "node_modules/reference-spec-reader": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/reference-spec-reader/-/reference-spec-reader-0.2.0.tgz",
+            "integrity": "sha512-q0mfCi5yZSSHXpCyxjgQeaORq3tvDsxDyzaadA/5+AbAUwRyRuuTh0aRQuE/vAOt/qzzxidJ5iDeu1cLHaNBlQ==",
+            "license": "MIT"
+        },
         "node_modules/reflect.getprototypeof": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -26808,6 +26833,18 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/unzipit": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/unzipit/-/unzipit-1.4.3.tgz",
+            "integrity": "sha512-gsq2PdJIWWGhx5kcdWStvNWit9FVdTewm4SEG7gFskWs+XCVaULt9+BwuoBtJiRE8eo3L1IPAOrbByNLtLtIlg==",
+            "license": "MIT",
+            "dependencies": {
+                "uzip-module": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/update-browserslist-db": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -27104,6 +27141,12 @@
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
+        },
+        "node_modules/uzip-module": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/uzip-module/-/uzip-module-1.0.3.tgz",
+            "integrity": "sha512-AMqwWZaknLM77G+VPYNZLEruMGWGzyigPK3/Whg99B3S6vGHuqsyl5ZrOv1UUF3paGK1U6PM0cnayioaryg/fA==",
+            "license": "MIT"
         },
         "node_modules/value-equal": {
             "version": "1.0.1",
@@ -28688,6 +28731,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/zarrita": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.5.1.tgz",
+            "integrity": "sha512-cyujP70BOl5DiXuLtM+0j9nq/pAov4SKXRYIQQOVnk2TfBg/jopX+FXLbqkq3ULOxFLB5AwkPbSp5KvZXoJrbQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@zarrita/storage": "^0.1.1",
+                "numcodecs": "^0.3.2"
+            }
+        },
         "node_modules/zip-stream": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
@@ -29055,7 +29108,8 @@
                 "array-equal": "^1.0.2",
                 "fflate": "^0.8.2",
                 "gl-matrix": "^3.4.3",
-                "nifti-reader-js": "^0.8.0"
+                "nifti-reader-js": "^0.8.0",
+                "zarrita": "^0.5.0"
             },
             "devDependencies": {
                 "@playwright/test": "^1.45.2",

--- a/packages/niivue/package.json
+++ b/packages/niivue/package.json
@@ -67,7 +67,8 @@
     "array-equal": "^1.0.2",
     "gl-matrix": "^3.4.3",
     "nifti-reader-js": "^0.8.0",
-    "fflate": "^0.8.2"
+    "fflate": "^0.8.2",
+    "zarrita": "^0.5.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.45.2",

--- a/packages/niivue/src/index_histo.html
+++ b/packages/niivue/src/index_histo.html
@@ -1,0 +1,227 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <title>NiiVue</title>
+    <link rel="stylesheet" href="niivue.css" />
+    <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
+  </head>
+  <body>
+    <noscript>
+      <strong>niivue requires JavaScript.</strong>
+    </noscript>
+    <header>
+      <label for="formatSelect">Format</label>
+      <select id="formatSelect">
+        <option  selected>Juelich histology MNI</option>
+        <option>Huge</option>
+        <option> Histology</option>
+        <option>ZARR</option>
+        <option>NPZ</option>
+        <option>DANDI</option>
+        <option>FS</option>
+        <option>Grayscale bitmap</option>
+        <option>Online ZARR</option>
+        <option>Online vizarr</option>
+        <option>mni152</option>
+      </select>
+      <label for="dragSelect">Drag</label>
+      <select id="dragSelect">
+        <option>None</option>
+        <option>Contrast</option>
+        <option>Measurement</option>
+        <option selected>Pan</option>
+      </select>
+      <label for="smoothCheck">Smooth</label>
+      <input type="checkbox" checked="true" id="smoothCheck" />
+        <button id="prevBtn">Previous Slice</button>
+        <button id="nextBtn">Next Slice</button>
+      &nbsp;&nbsp;&nbsp;
+      <select id="drawSelect">
+        <option value="-1">Off</option>
+        <option value="0">Erase</option>
+        <option value="1">Red</option>
+        <option value="2">Green</option>
+        <option value="3">Blue</option>
+        <option value="8">Filled Erase</option>
+        <option value="9" selected>Filled Red</option>
+        <option value="10">Filled Green</option>
+        <option value="11">Filled Blue</option>
+        <option value="12">Erase Selected Cluster</option>
+      </select>
+      <label for="opacitySlider">Opacity</label>
+      <input
+        type="range"
+        min="0"
+        max="100"
+        value="80"
+        class="slider"
+        id="opacitySlider"
+      />
+      <button id="undoBtn">Undo</button>
+      <button id="saveBtn">Save</button>
+      &nbsp;&nbsp;&nbsp;
+      <button id="aboutBtn">About</button>
+    </header>
+    <main id="canvas-container">
+      <div style="display: flex; width: 100%; height: 100%">
+        <canvas id="gl1"></canvas>
+      </div>
+    </main>
+    <footer id="statusText">&nbsp;</footer>
+    <script type="module" async>
+      import { Niivue, NVImage, NVMesh, NVMeshLoaders, SHOW_RENDER, DRAG_MODE } from './niivue/index.ts'
+      drawSelect.onchange = async function () {
+        const mode = parseInt(this.value)
+        nv1.setDrawingEnabled(mode >= 0)
+        if (mode >= 0) nv1.setPenValue(mode & 7, mode > 7)
+        if (mode === 12)
+          //erase selected cluster
+          nv1.setPenValue(-0)
+      }
+      opacitySlider.onchange = async function () {
+        nv1.setDrawOpacity(this.value * 0.01)
+      }
+      formatSelect.onchange = async function () {
+        const idx = this.selectedIndex
+        var volumeLists = [
+          [
+            {
+              url: '/mni100u8.nii.gz'
+            }
+          ],
+          [
+            {
+              url: '/retina.jpg'
+            }
+          ],
+          [
+            {
+              url: '/histology.nii.gz'
+            }
+          ],
+          [
+            {
+              url: 'http://localhost:5173/rgb.ome.zarr/scale0/image?z=1200',
+              name: 'example.zarr'
+            }
+          ],
+          [
+            {
+              url: '/c001_A_segmentation4.npz'
+            }
+          ],
+          [
+            {
+              url: 'https://niivue.github.io/niivue-demo-images/sub-370_sample-0002_TEM.png'
+            }
+          ],
+          [
+            {
+              url: 'https://niivue.github.io/niivue-demo-images/HCD1464653.qsdr.fz'
+            }
+          ],
+          [
+            {
+              url: 'https://niivue.github.io/niivue-demo-images/gray_bmp.png',
+              colormap: 'actc'
+            }
+          ],
+          [
+            {
+              url: 'https://raw.githubusercontent.com/zarr-developers/zarr_implementations/5dc998ac72/examples/zarr.zr/blosc',
+              name: 'example.zarr'
+            }
+          ],
+          [
+            {
+              // https://hms-dbmi.github.io/vizarr/?source=https://minio-dev.openmicroscopy.org/idr/v0.3/idr0062-blin-nuclearsegmentation/6001240.zarr&viewState={%22target%22:[148.82158305779987,128.923106260876],%22zoom%22:2.3938329406834296}
+              
+              url: 'https://minio-dev.openmicroscopy.org/idr/v0.3/idr0062-blin-nuclearsegmentation/6001240.zarr',
+              name: 'example.zarr'
+            }
+          ],
+          [
+            {
+              url: '../demos/images/mni152.nii.gz'
+            }
+          ]
+        ]
+        await nv1.loadVolumes(volumeLists[this.selectedIndex])
+      }
+      aboutBtn.onclick = async function () {
+        alert(nv1.volumes[0].hdr.toFormattedString())
+        // await nv1.loadDrawingFromUrl("./retina_draw.nii.gz")
+      }
+      undoBtn.onclick = async function () {
+        nv1.drawUndo()
+      }
+      saveBtn.onclick = async function () {
+        nv1.saveImage({ filename: 'test.nii', isSaveDrawing: true})
+      }
+      prevBtn.onclick = async function () {
+         nv1.moveCrosshairInVox(0, 0, -1)
+      }
+      nextBtn.onclick = async function () {
+         nv1.moveCrosshairInVox(0, 0, 1)
+      }
+      dragSelect.onchange = function () {
+        const drag = this.options[this.selectedIndex].text
+        console.log(drag)
+        if (drag === 'None') {
+          nv1.opts.dragMode = nv1.dragModes.none
+        } else if (drag === 'Contrast') {
+          nv1.opts.dragMode = nv1.dragModes.contrast
+        } else if (drag === 'Measurement') {
+          nv1.opts.dragMode = nv1.dragModes.measurement
+        } else if (drag === 'Pan') {
+          nv1.opts.dragMode = nv1.dragModes.pan
+        }
+      }
+      smoothCheck.onchange = function () {
+        nv1.setInterpolation(!this.checked)
+      }
+      const onLocationChange = (data) => {
+        statusText.innerHTML = '&nbsp;&nbsp;' + data.string + ` slice: ${data.vox[2]+1}/${nv1.back.dims[3]}`
+      }
+      let defaults = {
+        backColor: [0, 0.2, 0.3, 1],
+        show3Dcrosshair: true,
+        //logLevel: 'debug',
+        isRuler: true,
+        dragMode: DRAG_MODE.pan,
+        onLocationChange: onLocationChange,
+        showMeasureUnits: true,
+        measureTextColor: [0, 1, 0, 1],
+        measureLineColor: [1, 0, 0, 1],
+        measureTextHeight: 0.04
+      }
+      var nv1 = new Niivue(defaults)
+      nv1.attachToCanvas(gl1)
+      nv1.onImageLoaded = (volume) => {
+        nv1.closeDrawing()
+        drawSelect.onchange()
+        opacitySlider.onchange()
+        nv1.setVolumeRenderIllumination(0)
+        if (nv1.volumes[0].hdr.dims[3] > 1) {
+          prevBtn.style.display = 'inline-block'
+          nextBtn.style.display = 'inline-block'
+          if (nv1.opts.is2DSliceShader) {
+            nv1.setSliceType(nv1.sliceTypeAxial)
+            nv1.setVolumeRenderIllumination(-1)
+          } else {
+            nv1.setSliceType(nv1.sliceTypeMultiplanar)
+          }
+        } else {
+          prevBtn.style.display = 'none'
+          nextBtn.style.display = 'none'
+          nv1.setSliceType(nv1.sliceTypeAxial)
+        }
+      }
+      formatSelect.selectedIndex = 3
+      await formatSelect.onchange()
+    </script>
+  </body>
+</html>

--- a/packages/niivue/src/nvdocument.ts
+++ b/packages/niivue/src/nvdocument.ts
@@ -199,6 +199,7 @@ export type NVConfigOptions = {
   renderSilhouette: number
   gradientAmount: number
   invertScrollDirection: boolean
+  is2DSliceShader: boolean
 }
 
 export const DEFAULT_OPTIONS: NVConfigOptions = {
@@ -303,7 +304,8 @@ export const DEFAULT_OPTIONS: NVConfigOptions = {
   gradientOpacity: 0.0,
   renderSilhouette: 0.0,
   gradientAmount: 0.0,
-  invertScrollDirection: false
+  invertScrollDirection: false,
+  is2DSliceShader: false
 }
 
 type SceneData = {

--- a/packages/niivue/src/nvimage/index.ts
+++ b/packages/niivue/src/nvimage/index.ts
@@ -1,4 +1,5 @@
 import { NIFTI1, NIFTI2, NIFTIEXTENSION, readHeaderAsync } from 'nifti-reader-js'
+import * as zarr from 'zarrita'
 import { mat3, mat4, vec3, vec4 } from 'gl-matrix'
 import { v4 as uuidv4 } from '@lukeed/uuid'
 import { Gunzip } from 'fflate'
@@ -504,7 +505,8 @@ export class NVImage {
     cal_maxNeg = NaN,
     colorbarVisible = true,
     colormapLabel: LUT | null = null,
-    colormapType = 0
+    colormapType = 0,
+    zarrData: null | unknown
   ): Promise<NVImage> {
     const newImg = new NVImage()
     const re = /(?:\.([^.]+))?$/
@@ -583,8 +585,8 @@ export class NVImage {
         imgRaw = await newImg.readNPZ(dataBuffer as ArrayBuffer)
         break
       case NVIMAGE_TYPE.ZARR:
-        // imgRaw = await newImg.readZARR(dataBuffer as ArrayBuffer, zarrData)
-        throw new Error('Image type ZARR not (yet) supported')
+        imgRaw = await newImg.readZARR(dataBuffer as ArrayBuffer, zarrData)
+        break
       case NVIMAGE_TYPE.NII:
         imgRaw = await ImageReaders.Nii.readNifti(newImg, dataBuffer as ArrayBuffer)
         if (imgRaw === null) {
@@ -1327,6 +1329,61 @@ export class NVImage {
     return data.buffer as ArrayBuffer
   }
 
+  async readZARR(buffer: ArrayBuffer, zarrData: unknown): Promise<Uint8Array> {
+    let { width, height, depth = 1, data } = (zarrData ?? {}) as any
+    let expectedLength = width * height * depth * 3
+    let isRGB = expectedLength === data.length
+    if (!isRGB) {
+      expectedLength = width * height * depth
+      if (depth === 3) {
+        // see https://zarrita.dev/get-started.html R,G,B channels returns as depth!
+        isRGB = true
+        depth = 1
+      }
+    }
+    if (expectedLength !== data.length) {
+      throw new Error(`Expected RGB ${width}×${height}×${depth}×3 =  ${expectedLength}, but ZARR length ${data.length}`)
+    }
+    this.hdr = new NIFTI1()
+    const hdr = this.hdr
+    hdr.dims = [3, width, height, depth, 1, 1, 1, 1]
+    hdr.pixDims = [1, 1, 1, 1, 0, 0, 0, 0]
+
+    hdr.affine = [
+      [hdr.pixDims[1], 0, 0, -(hdr.dims[1] - 2) * 0.5 * hdr.pixDims[1]],
+      [0, -hdr.pixDims[2], 0, (hdr.dims[2] - 2) * 0.5 * hdr.pixDims[2]],
+      [0, 0, -hdr.pixDims[3], (hdr.dims[3] - 2) * 0.5 * hdr.pixDims[3]],
+      [0, 0, 0, 1]
+    ]
+    if (!isRGB) {
+      hdr.numBitsPerVoxel = 8
+      hdr.datatypeCode = NiiDataType.DT_UINT8
+      return data
+    }
+    hdr.numBitsPerVoxel = 24
+    hdr.datatypeCode = NiiDataType.DT_RGB24
+    function zxy2xyz(data, X, Y, Z): Uint8Array {
+      const voxelCount = X * Y
+      const rgb = new Uint8Array(voxelCount * Z * 3)
+      const offsets = new Array(Z)
+      for (let s = 0; s < Z; s++) {
+        offsets[s] = voxelCount * 3 * s
+      }
+      let srcIndex = 0
+      let dstIndex = 0
+      for (let v = 0; v < voxelCount; v++) {
+        for (let s = 0; s < Z; s++) {
+          rgb[offsets[s] + dstIndex] = data[srcIndex++] // R
+          rgb[offsets[s] + dstIndex + 1] = data[srcIndex++] // G
+          rgb[offsets[s] + dstIndex + 2] = data[srcIndex++] // B
+        }
+        dstIndex += 3
+      }
+      return rgb
+    }
+    return zxy2xyz(data, hdr.dims[1], hdr.dims[2], hdr.dims[3])
+  }
+
   // not included in public docs
   // read brainvoyager format VMR image
   // https://support.brainvoyager.com/brainvoyager/automation-development/84-file-formats/343-developer-guide-2-6-the-format-of-vmr-files
@@ -1485,7 +1542,6 @@ export class NVImage {
     const buff8 = new Uint8Array(new ArrayBuffer(nBytes))
     const arrFA = Float32Array.from(mat.dti_fa)
     if ('mask' in mat) {
-      console.log(mat)
       let slope = 1
       if ('dti_fa_slope' in mat) {
         slope = mat.dti_fa_slope[0]
@@ -2916,10 +2972,7 @@ export class NVImage {
         throw Error(response.statusText)
       }
       const contents = await response.arrayBuffer()
-      dataBuffer.push({
-        name: line,
-        data: contents
-      })
+      dataBuffer.push({ name: line, data: contents })
     }
     return dataBuffer
   }
@@ -3141,6 +3194,7 @@ export class NVImage {
     }
     let nvimage = null
     let dataBuffer = null
+    let zarrData: null | unknown = null
 
     // Handle input buffer types
     if (url instanceof Uint8Array) {
@@ -3185,6 +3239,59 @@ export class NVImage {
             imageType = NVIMAGE_TYPE.parse(ext)
           }
         }
+      }
+    }
+    // try url and name attributes to test for .zarr
+    if (imageType === NVIMAGE_TYPE.ZARR) {
+      // get the z, x, y slice indices from the query string
+      const urlParams = new URL(url).searchParams
+      const zIndex = urlParams.get('z')
+      const yIndex = urlParams.get('y')
+      const xIndex = urlParams.get('x')
+      const zRange = zIndex ? zarr.slice(parseInt(zIndex), parseInt(zIndex) + 1) : null
+      const yRange = yIndex ? zarr.slice(parseInt(yIndex), parseInt(yIndex) + 1) : null
+      const xRange = xIndex ? zarr.slice(parseInt(xIndex), parseInt(xIndex) + 1) : null
+      // remove the query string from the original URL
+      const zarrUrl = url.split('?')[0]
+      // if multiscale, must provide the full path to the zarr array data
+      const store = new zarr.FetchStore(zarrUrl)
+      const root = zarr.root(store)
+      let arr
+      try {
+        // TODO: probably remove this, since it's not needed
+        arr = await zarr.open(root.resolve(url), { kind: 'array' })
+      } catch (e) {
+        arr = await zarr.open(root, { kind: 'array' })
+      }
+      console.log('arr', arr)
+      let view
+      if (arr.shape.length === 4) {
+        const cRange = null
+        // make sure we are not exceeding the array shape. If so, set to max
+        const zDim = arr.shape[2]
+        const yDim = arr.shape[1]
+        const xDim = arr.shape[0]
+        if (zRange && zRange[0] >= zDim) {
+          zRange[0] = zDim - 1
+        }
+        if (yRange && yRange[0] >= yDim) {
+          yRange[0] = yDim - 1
+        }
+        if (xRange && xRange[0] >= xDim) {
+          xRange[0] = xDim - 1
+        }
+        view = await zarr.get(arr, [xRange, yRange, zRange, cRange])
+      } else {
+        view = await zarr.get(arr, [xRange, yRange, zRange])
+      }
+      dataBuffer = view.data
+      const [height, width, zDim, cDim] = view.shape
+      zarrData = {
+        data: dataBuffer,
+        width,
+        height,
+        depth: zDim,
+        channels: cDim
       }
     }
     // DICOM assigned for unknown extensions: therefore test signature to see if mystery file is NIfTI
@@ -3300,7 +3407,13 @@ export class NVImage {
       useQFormNotSForm,
       colormapNegative,
       frame4D,
-      imageType
+      imageType,
+      NaN,
+      NaN,
+      true,
+      null,
+      0,
+      zarrData
     )
     nvimage.url = url
     nvimage.colorbarVisible = colorbarVisible
@@ -3645,19 +3758,7 @@ export class NVImage {
     const dt = pixDims[4]
     const bpv = Math.floor(this.hdr.numBitsPerVoxel / 8)
 
-    return {
-      id,
-      datatypeCode,
-      nx,
-      ny,
-      nz,
-      nt,
-      dx,
-      dy,
-      dz,
-      dt,
-      bpv
-    }
+    return { id, datatypeCode, nx, ny, nz, nt, dx, dy, dz, dt, bpv }
   }
 
   /**

--- a/packages/niivue/src/nvimage/index.ts
+++ b/packages/niivue/src/nvimage/index.ts
@@ -3545,7 +3545,13 @@ export class NVImage {
         useQFormNotSForm,
         colormapNegative,
         frame4D,
-        imageType
+        imageType,
+        NaN,
+        NaN,
+        true,
+        null,
+        0,
+        null
       )
       // add a reference to the file object as a new property of the NVImage instance
       // is this too hacky?
@@ -3694,7 +3700,9 @@ export class NVImage {
         cal_minNeg,
         cal_maxNeg,
         colorbarVisible,
-        colormapLabel
+        colormapLabel,
+        0,
+        null
       )
     } catch (err) {
       log.debug(err)

--- a/packages/niivue/src/shader-srcs.ts
+++ b/packages/niivue/src/shader-srcs.ts
@@ -696,6 +696,38 @@ out vec4 color;` +
 	}
 
 `
+
+export const fragSlice2DShader =
+  `#version 300 es
+#line 411
+precision highp int;
+precision highp float;
+uniform highp sampler2D volume, overlay;
+uniform int backgroundMasksOverlays;
+uniform float overlayOutlineWidth;
+uniform float overlayAlphaShader;
+uniform int axCorSag;
+uniform float overlays;
+uniform float opacity;
+uniform float drawOpacity;
+uniform bool isAlphaClipDark;
+uniform highp sampler2D drawing;
+uniform highp sampler2D colormap;
+in vec3 texPos;
+out vec4 color;` +
+  kDrawFunc +
+  `void main() {
+	//color = vec4(1.0, 0.0, 1.0, 1.0);return;
+	vec4 background = texture(volume, texPos.xy);
+	color = vec4(background.rgb, opacity);
+	if ((isAlphaClipDark) && (background.a == 0.0)) color.a = 0.0; //FSLeyes clipping range
+	vec4 dcolor = drawColor(texture(drawing, texPos.xy).r, drawOpacity);
+	if (dcolor.a > 0.0) {
+		color.rgb = mix(color.rgb, dcolor.rgb, dcolor.a);
+		color.a = max(drawOpacity, color.a);
+	}
+}`
+
 export const kFragSliceTail = `	ocolor.a *= overlayAlpha;
 	vec4 dcolor = drawColor(texture(drawing, texPos).r, drawOpacity);
 	if (dcolor.a > 0.0) {


### PR DESCRIPTION
This PR cleans up the implementation from the previous experimental zarr branch #1200.

Now, full slices from zarr arrays can be fetched using url query strings: 
`http://localhost:5173/rgb.ome.zarr/scale0/image?z=1200`

This needs to be combined with the `name` attribute when loading images in NiiVue. 

```javascript
{
  url: 'http://localhost:5173/rgb.ome.zarr/scale0/image?z=1200',
  name: 'example.zarr'
}
```
closes #1200 