### PR TITLE
limit gradient opacity lut count to 192

### DIFF
--- a/packages/niivue/src/niivue/index.ts
+++ b/packages/niivue/src/niivue/index.ts
@@ -64,7 +64,8 @@ import {
   blurFragShader,
   sobelBlurFragShader,
   sobelFirstOrderFragShader,
-  sobelSecondOrderFragShader
+  sobelSecondOrderFragShader,
+  gradientOpacityLutCount
 } from '../shader-srcs.js'
 import { orientCube } from '../orientCube.js'
 import { NiivueObject3D } from '../niivue-object3D.js'
@@ -6532,12 +6533,12 @@ export class Niivue {
     this.gl.uniform1fv(shader.uniforms.renderDrawAmbientOcclusion, [this.renderDrawAmbientOcclusion, 1.0])
     this.gl.uniform1f(shader.uniforms.gradientAmount, gradientAmount)
     this.gl.uniform1f(shader.uniforms.silhouettePower, this.opts.renderSilhouette)
-    const gradientOpacityLut = new Float32Array(256)
-    for (let i = 0; i < 256; i++) {
+    const gradientOpacityLut = new Float32Array(gradientOpacityLutCount)
+    for (let i = 0; i < gradientOpacityLutCount; i++) {
       if (this.opts.gradientOpacity === 0.0) {
         gradientOpacityLut[i] = 1.0
       } else {
-        gradientOpacityLut[i] = Math.pow(i / 255.0, this.opts.gradientOpacity * 8.0)
+        gradientOpacityLut[i] = Math.pow(i / (gradientOpacityLutCount - 1.0), this.opts.gradientOpacity * 8.0)
       }
     }
     this.gl.uniform1fv(this.gl.getUniformLocation(shader.program, 'gradientOpacity'), gradientOpacityLut)

--- a/packages/niivue/src/shader-srcs.ts
+++ b/packages/niivue/src/shader-srcs.ts
@@ -442,6 +442,8 @@ out vec4 fColor;
 ` +
   kRenderTail
 
+export const gradientOpacityLutCount = 192
+
 const kFragRenderGradientDecl = `#version 300 es
 #line 215
 precision highp int;
@@ -468,7 +470,7 @@ uniform highp sampler2D matCap;
 uniform vec2 renderDrawAmbientOcclusionXY;
 uniform float gradientAmount;
 uniform float silhouettePower;
-uniform float gradientOpacity[256];
+uniform float gradientOpacity[${gradientOpacityLutCount}];
 in vec3 vColor;
 out vec4 fColor;
 `


### PR DESCRIPTION
The fragment shader can fail to compile on mobile browsers / mobile
GPU's where it is more common to run into the WebGL2 limit of 224
uniforms for fragment shaders.

xref: https://webglfundamentals.org/webgl/lessons/webgl-cross-platform-issues.html
