### PR TITLE
Update bundle scripts for saving as HTML

### DIFF
--- a/packages/niivue/bundle.js
+++ b/packages/niivue/bundle.js
@@ -18,7 +18,7 @@ import { build } from 'tsup'
     },
     minify: 'terser',
     terserOptions: {
-      mangle: false,
+      mangle: false
     },
     noExternal: [/(.*)/]
   })

--- a/packages/niivue/bundle.js
+++ b/packages/niivue/bundle.js
@@ -16,7 +16,11 @@ import { build } from 'tsup'
       '.jpg': 'dataurl',
       '.png': 'dataurl'
     },
-    minify: 'terser'
+    minify: 'terser',
+    terserOptions: {
+      mangle: false,
+    },
+    noExternal: [/(.*)/]
   })
 
   // load output and export it again as a string

--- a/packages/niivue/bundleForDemos.js
+++ b/packages/niivue/bundleForDemos.js
@@ -18,7 +18,7 @@ import { build } from 'tsup'
     },
     minify: 'terser',
     terserOptions: {
-      mangle: false,
+      mangle: false
     },
     noExternal: [/(.*)/]
   })

--- a/packages/niivue/bundleForDemos.js
+++ b/packages/niivue/bundleForDemos.js
@@ -17,6 +17,9 @@ import { build } from 'tsup'
       '.png': 'dataurl'
     },
     minify: 'terser',
+    terserOptions: {
+      mangle: false,
+    },
     noExternal: [/(.*)/]
   })
 


### PR DESCRIPTION
This is Anthony Androulakis' [Update bundle scripts for saving as HTML](https://github.com/niivue/niivue/pull/1312) rebased on niivue/main.

Fixes issue:
- https://github.com/niivue/niivue/issues/1309

This also essentially fixes this issue on ipyniivue:
- https://github.com/niivue/ipyniivue/issues/117

Mangle is set to false to preserve export names. 
Additionally, I added the noExternal setting to bundle.js so that the index.min.js for non-demo purposes is standalone (this is useful for applications in ipyniivue).