### PR TITLE
Custom gradient opacity

### DIFF
--- a/packages/niivue/demos/features/gradient.custom.html
+++ b/packages/niivue/demos/features/gradient.custom.html
@@ -1,0 +1,279 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <title>Custom Gradient Opacity</title>
+    <link rel="stylesheet" href="niivue.css" />
+    <style>
+      header {
+        padding: 10px;
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 10px;
+      }
+
+      header label {
+        margin-right: 5px;
+        font-weight: bold;
+      }
+
+      header input, header select {
+        margin-right: 15px;
+      }
+
+      #createDistanceMap {
+        background-color: #4CAF50;
+        color: white;
+        padding: 8px 16px;
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 14px;
+      }
+
+      #createDistanceMap:hover {
+        background-color: #45a049;
+      }
+
+      #createDistanceMap:disabled {
+        background-color: #cccccc;
+        cursor: not-allowed;
+      }
+
+      #status {
+        font-style: italic;
+        color: #666;
+        margin-left: 10px;
+      }
+    </style>
+  </head>
+  <body>
+    <noscript>
+      <strong>niivue requires JavaScript.</strong>
+    </noscript>
+    <header>
+      <label for="gradientOpacity">Gradient Opacity</label>
+      <input type="range" min="0" max="10" value="6" class="slider" id="gradientOpacity">
+      <label for="silhouetteEnhancement">Silhouette Enhancement</label>
+      <input type="range" min="0" max="19" value="10" class="slider" id="silhouetteEnhancement">
+      <label for="gradientOrder">Gradient Order</label>
+      <select id="gradientOrder">
+        <option value="1">1</option>
+        <option value="2" selected>2</option>
+      </select>
+      <label for="illumination">Illumination</label>
+      <input type="range" min="0" max="10" value="7" class="slider" id="illumination">
+      <label for="gradientModulation">Center Modulation</label>
+      <input type="range" min="0" max="100" value="75" class="slider" id="gradientModulation">
+      <button id="createDistanceMap">Apply Center Distance Modulation</button>
+      <span id="status"></span>
+    </header>
+    <main id="canvas-container">
+      <div style="display: flex; width: 100%; height: 100%">
+        <canvas id="gl1" height="1024"></canvas>
+      </div>
+    </main>
+    <footer id="intensity">&nbsp;</footer>
+    <script type="module" async>
+      import { Niivue, NVImage, SHOW_RENDER, DRAG_MODE } from '../dist/index.js'
+
+      let originalGradientData = null
+      let centerDistanceMap = null
+      let currentModulation = 0
+
+      function createCenterDistanceMap() {
+        try {
+          console.log('Creating center-based distance map...')
+
+          // Check if volumes are loaded
+          if (!nv1.volumes || nv1.volumes.length === 0) {
+            console.error('No volumes loaded')
+            document.getElementById('status').textContent = 'No volumes loaded'
+            return false
+          }
+
+          // Use the first volume for dimensions
+          const volume = nv1.volumes[0]
+          const dims = volume.hdr?.dims || volume.dims
+          if (!dims || dims.length < 4) {
+            console.error('Volume dimensions not available:', dims)
+            document.getElementById('status').textContent = 'Volume dimensions not available'
+            return false
+          }
+
+          const [, nx, ny, nz] = dims
+          const numVoxels = nx * ny * nz
+
+          // Calculate center coordinates
+          const centerX = (nx - 1) / 2
+          const centerY = (ny - 1) / 2
+          const centerZ = (nz - 1) / 2
+
+          // Create distance map from center
+          centerDistanceMap = new Float32Array(numVoxels)
+          let maxDistance = 0
+
+          for (let z = 0; z < nz; z++) {
+            for (let y = 0; y < ny; y++) {
+              for (let x = 0; x < nx; x++) {
+                const idx = z * nx * ny + y * nx + x
+
+                // Calculate Euclidean distance from center
+                const dx = x - centerX
+                const dy = y - centerY
+                const dz = z - centerZ
+                const distance = Math.sqrt(dx*dx + dy*dy + dz*dz)
+
+                centerDistanceMap[idx] = distance
+                maxDistance = Math.max(maxDistance, distance)
+              }
+            }
+          }
+
+          // Normalize to 0-1 range (1.0 at center, 0.0 at max distance)
+          for (let i = 0; i < numVoxels; i++) {
+            centerDistanceMap[i] = 1.0 - (centerDistanceMap[i] / maxDistance)
+          }
+
+          return true
+
+        } catch (error) {
+          console.error('Error creating center distance map:', error)
+          document.getElementById('status').textContent = `Error: ${error.message}`
+          return false
+        }
+      }
+
+      function modulateGradientByCenter(modulation) {
+        if (!originalGradientData || !centerDistanceMap) {
+          console.warn('Original gradient data or center distance map not available')
+          document.getElementById('status').textContent = 'Distance map not created yet'
+          return
+        }
+
+        const modulatedGradient = new Float32Array(originalGradientData.length)
+        const numVoxels = centerDistanceMap.length
+        const gradientNumVoxels = originalGradientData.length / 4 // RGBA components
+
+        // Handle size mismatch between gradient and distance data
+        const useVoxelCount = Math.min(numVoxels, gradientNumVoxels)
+
+        for (let i = 0; i < useVoxelCount; i++) {
+          const baseIdx = i * 4
+          const centerDistance = centerDistanceMap[i] // 1.0 at center, 0.0 at boundary
+
+          // Apply modulation to alpha channel
+          // modulation = 0: no effect (alpha unchanged)
+          // modulation = 1: full effect (alpha = centerDistance, so 1.0 at center, 0.0 at boundary)
+          const alphaMultiplier = Math.pow(1.0 - modulation + (modulation * centerDistance), 5.0)
+
+          // Keep RGB unchanged, modulate alpha
+          modulatedGradient[baseIdx + 0] = originalGradientData[baseIdx + 0] // R
+          modulatedGradient[baseIdx + 1] = originalGradientData[baseIdx + 1] // G
+          modulatedGradient[baseIdx + 2] = originalGradientData[baseIdx + 2] // B
+          modulatedGradient[baseIdx + 3] = originalGradientData[baseIdx + 3] * alphaMultiplier // A (modulated)
+        }
+
+        // Copy remaining gradient data unchanged if gradient is larger
+        for (let i = useVoxelCount * 4; i < originalGradientData.length; i++) {
+          modulatedGradient[i] = originalGradientData[i]
+        }
+
+        nv1.setCustomGradientTexture(modulatedGradient)
+        document.getElementById('status').textContent = `Center modulation: ${Math.round(modulation * 100)}%`
+      }
+
+      async function createAndApplyModulation() {
+        try {
+          document.getElementById('createDistanceMap').disabled = true
+          document.getElementById('createDistanceMap').textContent = 'Processing...'
+          document.getElementById('status').textContent = 'Creating center distance map...'
+
+          // Get the original gradient data
+          originalGradientData = nv1.getGradientTextureData()
+          if (!originalGradientData) {
+            console.warn('Could not get gradient texture data')
+            document.getElementById('status').textContent = 'Could not get gradient data'
+            return
+          }
+
+          // Create center-based distance map
+          if (!createCenterDistanceMap()) {
+            return
+          }
+
+          // Apply initial modulation
+          currentModulation = gradientModulation.value / 100.0
+          modulateGradientByCenter(currentModulation)
+
+        } catch (error) {
+          console.error('Error in createAndApplyModulation:', error)
+          document.getElementById('status').textContent = `Error: ${error.message}`
+        } finally {
+          document.getElementById('createDistanceMap').disabled = false
+          document.getElementById('createDistanceMap').textContent = 'Apply Center Distance Modulation'
+        }
+      }
+
+      gradientOpacity.oninput = function () {
+        nv1.setGradientOpacity(gradientOpacity.value * 0.1, silhouetteEnhancement.value * 0.05)
+        modulateGradientByCenter(currentModulation)
+      }
+      silhouetteEnhancement.oninput = function () {
+        nv1.setGradientOpacity(gradientOpacity.value * 0.1, silhouetteEnhancement.value * 0.05)
+        modulateGradientByCenter(currentModulation)
+      }
+      illumination.oninput = function () {
+        nv1.setVolumeRenderIllumination(this.value * 0.1)
+        modulateGradientByCenter(currentModulation)
+      }
+      gradientOrder.onchange = function () {
+        nv1.opts.gradientOrder = parseInt(this.value)
+        nv1.updateGLVolume()
+      }
+      gradientModulation.oninput = function () {
+        const modulation = this.value / 100.0
+        currentModulation = modulation
+        modulateGradientByCenter(modulation)
+      }
+      createDistanceMap.onclick = createAndApplyModulation
+      var volumeList1 = [
+        {
+          url: "../images/mni152.nii.gz",
+          colormap: "gray",
+          visible: true,
+          opacity: 1.0
+        },
+        {
+          url: "../images/hippo.nii.gz",
+          colormap: "red",
+          visible: true,
+          opacity: 1.0
+        }
+      ];
+
+      function handleIntensityChange(data) {
+        document.getElementById("intensity").innerHTML = data.string
+      }
+      const clipPlane = [0.35, 290, 0]
+      const defaults = {
+        backColor: [0.5, 0.5, 1, 1],
+        show3Dcrosshair: true,
+        loglevel: 'debug',
+        isRuler: true,
+        onLocationChange: handleIntensityChange,
+      }
+      var nv1 = new Niivue(defaults)
+      await nv1.attachToCanvas(gl1)
+      nv1.loadVolumes(volumeList1)
+      nv1.setSliceType(nv1.sliceTypeRender)
+      nv1.setClipPlane(clipPlane)
+      nv1.opts.gradientOrder = 2
+      nv1.setGradientOpacity(gradientOpacity.value * 0.1, silhouetteEnhancement.value * 0.05)
+      nv1.setVolumeRenderIllumination(0.7)
+    </script>
+  </body>
+</html>

--- a/packages/niivue/demos/index.html
+++ b/packages/niivue/demos/index.html
@@ -138,6 +138,7 @@
 <li><a href="./features/labels.anchored.html" target="_blank" rel="noopener noreferrer">Labels: Anchored</a></li>
 <li><a href="./features/gradient.order.html" target="_blank" rel="noopener noreferrer">Gradient Order</a></li>
 <li><a href="./features/gradient.opacity.html" target="_blank" rel="noopener noreferrer">Gradient Opacity</a></li>
+<li><a href="./features/gradient.custom.html" target="_blank" rel="noopener noreferrer">Custom Gradient Opacity</a></li>
 <li><a href="./features/magic_wand.html" target="_blank" rel="noopener noreferrer">Magic wand</a></li>
 
       </ul>

--- a/packages/niivue/src/niivue/index.ts
+++ b/packages/niivue/src/niivue/index.ts
@@ -370,6 +370,7 @@ export class Niivue {
   volumeTexture: WebGLTexture | null = null // the GPU memory storage of the volume
   gradientTexture: WebGLTexture | null = null // 3D texture for volume rendering lighting
   gradientTextureAmount = 0.0
+  useCustomGradientTexture = false // flag to indicate if a custom gradient texture is used
   renderGradientValues = false
   drawTexture: WebGLTexture | null = null // the GPU memory storage of the drawing
   drawUndoBitmaps: Uint8Array[] = [] // array of drawBitmaps for undo
@@ -6842,6 +6843,175 @@ export class Niivue {
     gl.deleteTexture(tempTex3D)
     gl.deleteBuffer(vbo2)
     gl.bindFramebuffer(gl.FRAMEBUFFER, null)
+  } /**
+   * Get the gradient texture produced by gradientGL as a TypedArray
+   * @returns Float32Array containing the gradient texture data, or null if no gradient texture exists
+   * @example
+   * niivue = new Niivue()
+   * niivue.loadVolumes([{url: './someImage.nii'}])
+   * // ... after volume is loaded and gradient is computed
+   * const gradientData = niivue.getGradientTextureData()
+   * if (gradientData) {
+   *   console.log('Gradient texture dimensions:', gradientData.length)
+   * }
+   */
+
+  getGradientTextureData(): Float32Array | null {
+    if (!this.gradientTexture || !this.back) {
+      return null
+    }
+
+    const gl = this.gl
+    const dims = this.back.dims!
+    const width = dims[1]
+    const height = dims[2]
+    const depth = dims[3]
+    const numVoxels = width * height * depth
+
+    // Create framebuffer to read from 3D texture
+    const fb = gl.createFramebuffer()
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fb)
+
+    // Create output array
+    const data = new Float32Array(numVoxels * 4) // RGBA components
+
+    try {
+      // Read each slice of the 3D texture
+      for (let slice = 0; slice < depth; slice++) {
+        // Attach the current slice to the framebuffer
+        gl.framebufferTextureLayer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, this.gradientTexture, 0, slice)
+
+        // Check framebuffer completeness
+        const status = gl.checkFramebufferStatus(gl.FRAMEBUFFER)
+        if (status !== gl.FRAMEBUFFER_COMPLETE) {
+          console.warn(
+            'Framebuffer not complete for gradient texture reading, slice',
+            slice,
+            'status:',
+            status.toString(16)
+          )
+          continue
+        }
+
+        // Read as UINT8 data (more compatible) and convert to float
+        try {
+          const byteData = new Uint8Array(width * height * 4)
+          gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, byteData)
+
+          // Convert from uint8 (0-255) to float (-1.0 to 1.0) range
+          const sliceData = new Float32Array(width * height * 4)
+          for (let i = 0; i < byteData.length; i++) {
+            sliceData[i] = byteData[i] / 127.5 - 1.0
+          }
+
+          // Copy slice data to output array
+          const sliceOffset = slice * width * height * 4
+          data.set(sliceData, sliceOffset)
+        } catch (readError) {
+          console.warn('Failed to read pixels for slice', slice, ':', readError)
+          // Fill with zeros for this slice
+          const sliceOffset = slice * width * height * 4
+          const zeroSlice = new Float32Array(width * height * 4)
+          data.set(zeroSlice, sliceOffset)
+        }
+      }
+    } catch (error) {
+      console.error('Error reading gradient texture:', error)
+      return null
+    } finally {
+      // Cleanup
+      gl.deleteFramebuffer(fb)
+      gl.bindFramebuffer(gl.FRAMEBUFFER, null)
+    }
+
+    return data
+  }
+
+  /**
+   * Set a custom gradient texture to use instead of the one produced by gradientGL
+   * When a custom gradient texture is set, the useCustomGradientTexture flag is set to true
+   * to prevent gradientGL from overwriting the custom texture during volume updates.
+   * @param data - Float32Array or Uint8Array containing RGBA gradient data, or null to revert to auto-generated gradient
+   * @param dims - Optional dimensions array [width, height, depth]. If not provided, uses current volume dimensions
+   * @example
+   * niivue = new Niivue()
+   * niivue.loadVolumes([{url: './someImage.nii'}])
+   * // Create custom gradient data
+   * const customGradient = new Float32Array(256 * 256 * 256 * 4) // example dimensions
+   * // ... fill customGradient with desired values
+   * niivue.setCustomGradientTexture(customGradient, [256, 256, 256])
+   *
+   * // To revert to auto-generated gradient:
+   * niivue.setCustomGradientTexture(null)
+   */
+  setCustomGradientTexture(data: Float32Array | Uint8Array | null, dims?: number[]): void {
+    const gl = this.gl
+
+    if (data === null) {
+      // Revert to auto-generated gradient
+      this.useCustomGradientTexture = false
+      if (this.back && this.gradientTextureAmount > 0.0) {
+        this.gradientGL(this.back.hdr!)
+      }
+      return
+    }
+
+    if (!dims && !this.back) {
+      console.warn('No dimensions provided and no background volume loaded')
+      return
+    }
+
+    const texDims = dims || this.back!.dims!
+    const width = texDims[1]
+    const height = texDims[2]
+    const depth = texDims[3]
+    const expectedSize = width * height * depth * 4
+
+    if (data.length !== expectedSize) {
+      console.warn(`Custom gradient data size mismatch. Expected ${expectedSize}, got ${data.length}`)
+      return
+    }
+
+    // Set flag to indicate we're using a custom gradient texture
+    this.useCustomGradientTexture = true
+
+    // Delete existing gradient texture
+    if (this.gradientTexture !== null) {
+      gl.deleteTexture(this.gradientTexture)
+    }
+
+    // Create new texture
+    this.gradientTexture = gl.createTexture()
+    gl.activeTexture(TEXTURE6_GRADIENT)
+    gl.bindTexture(gl.TEXTURE_3D, this.gradientTexture)
+    gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
+    gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+    gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_WRAP_R, gl.CLAMP_TO_EDGE)
+    gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+    gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+    gl.pixelStorei(gl.UNPACK_ALIGNMENT, 1)
+
+    // Convert float data to uint8 if needed and use RGBA8 format for better compatibility
+    let textureData: Uint8Array
+    if (data instanceof Float32Array) {
+      // Convert float data (-1.0 to 1.0) to uint8 (0 to 255)
+      textureData = new Uint8Array(data.length)
+      for (let i = 0; i < data.length; i++) {
+        // Clamp to -1.0 to 1.0, then map to 0-255
+        const clampedValue = Math.max(-1.0, Math.min(1.0, data[i]))
+        textureData[i] = Math.round((clampedValue + 1.0) * 127.5)
+      }
+    } else {
+      // Data is already Uint8Array
+      textureData = data
+    }
+
+    // Use RGBA8 format for better WebGL compatibility
+    gl.texStorage3D(gl.TEXTURE_3D, 1, gl.RGBA8, width, height, depth)
+    gl.texSubImage3D(gl.TEXTURE_3D, 0, 0, 0, 0, width, height, depth, gl.RGBA, gl.UNSIGNED_BYTE, textureData)
+
+    // Redraw scene to apply changes
+    this.drawScene()
   }
 
   /**
@@ -7685,9 +7855,9 @@ export class Niivue {
 
     if (layer === 0) {
       this.volumeTexture = outTexture
-      if (this.gradientTextureAmount > 0.0) {
+      if (this.gradientTextureAmount > 0.0 && !this.useCustomGradientTexture) {
         this.gradientGL(hdr)
-      } else {
+      } else if (this.gradientTextureAmount <= 0.0) {
         if (this.gradientTexture !== null) {
           this.gl.deleteTexture(this.gradientTexture)
         }

--- a/packages/niivue/src/shader-srcs.ts
+++ b/packages/niivue/src/shader-srcs.ts
@@ -502,7 +502,7 @@ export const fragRenderGradientShader =
 				firstHit = samplePos;
 			backNearest = min(backNearest, samplePos.a);
 			colorSample.a = 1.0-pow((1.0 - colorSample.a), opacityCorrection);
-			int gradIdx = int(grad.a * 255.0);
+			int gradIdx = int(grad.a * ${gradientOpacityLutCount}.0);
 			colorSample.a *= gradientOpacity[gradIdx];
 			float lightNormDot = dot(grad.rgb, rayDir);
 			// n.b. "lightNormDor" is cosTheta, "silhouettePower" is Fresnel effect exponent


### PR DESCRIPTION
The ability to get GPU-computed gradient texture values. And set custom gradient values either derived from those values or computed independently.

A demo does an OK job of providing an example of how we can provide clearer context of how the hippocampus sits in the brain by modulating the gradient magnitude by its distance from the center of the volume.

![standard-opacity](https://github.com/user-attachments/assets/5ef09162-620e-45b7-8af5-fefafebd0d9e)
Standard

![custom-opacity](https://github.com/user-attachments/assets/8f0124b9-de8e-4a71-a6cc-7d4b5dafa9b5)
Customized