### PR TITLE
Hanayik/add configurable mouse actions

### DIFF
--- a/packages/niivue/demos/features/light.css
+++ b/packages/niivue/demos/features/light.css
@@ -35,7 +35,7 @@ canvas:focus {
 }
 div {
   display: table-row;
-  background-color: blue;
+  /* background-color: blue; */
 }
 .dropdown {
   float: left;

--- a/packages/niivue/demos/features/mouse_event_config.html
+++ b/packages/niivue/demos/features/mouse_event_config.html
@@ -18,6 +18,14 @@
         <select id="leftButtonSelect">
           <option value="crosshair">Crosshair positioning</option>
           <option value="windowing">Window/Level adjustment</option>
+          <option value="contrast">Contrast adjustment</option>
+          <option value="pan">Pan</option>
+          <option value="measurement">Measurement</option>
+          <option value="angle">Angle measurement</option>
+          <option value="slicer3D">3D Slicer</option>
+          <option value="callbackOnly">Callback Only</option>
+          <option value="roiSelection">ROI Selection</option>
+          <option value="none">None</option>
         </select>
       </div>
       <div>

--- a/packages/niivue/demos/features/mouse_event_config.html
+++ b/packages/niivue/demos/features/mouse_event_config.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <title>Custom Mouse Event Configuration</title>
+    <link rel="stylesheet" href="light.css" />
+  </head>
+  <body>
+    <noscript>
+      <strong>niivue requires JavaScript.</strong>
+    </noscript>
+    <header>
+      <h3>Mouse Button Configuration:</h3>
+      <div>
+        <label for="leftButtonSelect">Left Button:</label>
+        <select id="leftButtonSelect">
+          <option value="crosshair">Crosshair positioning</option>
+          <option value="windowing">Window/Level adjustment</option>
+        </select>
+      </div>
+      <div>
+        <label for="rightButtonSelect">Right Button:</label>
+        <select id="rightButtonSelect">
+          <option value="contrast">Contrast adjustment</option>
+          <option value="windowing">Window/Level adjustment</option>
+          <option value="crosshair">Crosshair positioning</option>
+          <option value="pan">Pan</option>
+          <option value="measurement">Measurement</option>
+          <option value="angle">Angle measurement</option>
+        </select>
+      </div>
+    </header>
+    <main id="container">
+      <canvas id="gl"></canvas>
+    </main>
+    <footer id="configInfo">
+      <h4>Current Configuration:</h4>
+      <div id="configDisplay">
+        <p>Left Button: <span id="leftButtonDisplay">Crosshair positioning</span></p>
+        <p>Right Button: <span id="rightButtonDisplay">Contrast adjustment</span></p>
+        <p>Middle Button: Pan/Zoom (fixed)</p>
+      </div>
+    </footer>
+  </body>
+
+<script type="module" async>
+  import { Niivue, NVImage, DRAG_MODE, DRAG_MODE_PRIMARY } from '../dist/index.js'
+  
+  const nv = new Niivue()
+  await nv.attachTo('gl')
+  
+  // Load a sample image
+  const imageUrl = 'https://niivue.com/demos/images/mni152.nii.gz'
+  const volume = await NVImage.loadFromUrl({ url: imageUrl })
+  await nv.addVolume(volume)
+  
+  // Get select elements
+  const leftButtonSelect = document.getElementById('leftButtonSelect')
+  const rightButtonSelect = document.getElementById('rightButtonSelect')
+  const leftButtonDisplay = document.getElementById('leftButtonDisplay')
+  const rightButtonDisplay = document.getElementById('rightButtonDisplay')
+  
+  // Map select values to drag modes
+  const dragModeMap = {
+    crosshair: DRAG_MODE_PRIMARY.crosshair,
+    windowing: DRAG_MODE_PRIMARY.windowing,
+    contrast: DRAG_MODE.contrast,
+    pan: DRAG_MODE.pan,
+    measurement: DRAG_MODE.measurement,
+    angle: DRAG_MODE.angle
+  }
+  
+  // Map drag modes to display names
+  const displayNameMap = {
+    crosshair: 'Crosshair positioning',
+    windowing: 'Window/Level adjustment',
+    contrast: 'Contrast adjustment',
+    pan: 'Pan',
+    measurement: 'Measurement',
+    angle: 'Angle measurement'
+  }
+  
+  function updateConfiguration() {
+    const leftValue = leftButtonSelect.value
+    const rightValue = rightButtonSelect.value
+    
+    // Update display
+    leftButtonDisplay.textContent = displayNameMap[leftValue]
+    rightButtonDisplay.textContent = displayNameMap[rightValue]
+    
+    // Apply configuration to NiiVue
+    nv.setMouseEventConfig({
+      leftButton: {
+        primary: dragModeMap[leftValue]
+      },
+      rightButton: dragModeMap[rightValue],
+      centerButton: DRAG_MODE.pan
+    })
+  }
+  
+  // Add event listeners for select changes
+  leftButtonSelect.addEventListener('change', updateConfiguration)
+  rightButtonSelect.addEventListener('change', updateConfiguration)
+  
+  // Initialize with default configuration
+  updateConfiguration()
+</script>
+</body>
+</html>

--- a/packages/niivue/demos/features/mouse_event_config.html
+++ b/packages/niivue/demos/features/mouse_event_config.html
@@ -46,11 +46,19 @@
         <p>Right Button: <span id="rightButtonDisplay">Contrast adjustment</span></p>
         <p>Middle Button: Pan/Zoom (fixed)</p>
       </div>
+      <div id="testInstructions">
+        <h4>Testing Instructions:</h4>
+        <ul>
+          <li><strong>Contrast Mode:</strong> Right-click and drag to draw selection box, release to calculate contrast</li>
+          <li><strong>Callback Only Mode:</strong> Right-click and drag - should NOT draw selection box</li>
+          <li><strong>Windowing Mode:</strong> Click and drag for real-time brightness/contrast adjustment</li>
+        </ul>
+      </div>
     </footer>
   </body>
 
 <script type="module" async>
-  import { Niivue, NVImage, DRAG_MODE, DRAG_MODE_PRIMARY } from '../dist/index.js'
+  import { Niivue, NVImage, DRAG_MODE } from '../dist/index.js'
   
   const nv = new Niivue()
   await nv.attachTo('gl')
@@ -68,8 +76,8 @@
   
   // Map select values to drag modes
   const dragModeMap = {
-    crosshair: DRAG_MODE_PRIMARY.crosshair,
-    windowing: DRAG_MODE_PRIMARY.windowing,
+    crosshair: DRAG_MODE.crosshair,
+    windowing: DRAG_MODE.windowing,
     contrast: DRAG_MODE.contrast,
     pan: DRAG_MODE.pan,
     measurement: DRAG_MODE.measurement,

--- a/packages/niivue/demos/features/mouse_event_config.html
+++ b/packages/niivue/demos/features/mouse_event_config.html
@@ -29,6 +29,10 @@
           <option value="pan">Pan</option>
           <option value="measurement">Measurement</option>
           <option value="angle">Angle measurement</option>
+          <option value="slicer3D">3D Slicer</option>
+          <option value="callbackOnly">Callback Only</option>
+          <option value="roiSelection">ROI Selection</option>
+          <option value="none">None</option>
         </select>
       </div>
     </header>
@@ -69,7 +73,11 @@
     contrast: DRAG_MODE.contrast,
     pan: DRAG_MODE.pan,
     measurement: DRAG_MODE.measurement,
-    angle: DRAG_MODE.angle
+    angle: DRAG_MODE.angle,
+    slicer3D: DRAG_MODE.slicer3D,
+    callbackOnly: DRAG_MODE.callbackOnly,
+    roiSelection: DRAG_MODE.roiSelection,
+    none: DRAG_MODE.none
   }
   
   // Map drag modes to display names
@@ -79,7 +87,11 @@
     contrast: 'Contrast adjustment',
     pan: 'Pan',
     measurement: 'Measurement',
-    angle: 'Angle measurement'
+    angle: 'Angle measurement',
+    slicer3D: '3D Slicer',
+    callbackOnly: 'Callback Only',
+    roiSelection: 'ROI Selection',
+    none: 'None'
   }
   
   function updateConfiguration() {

--- a/packages/niivue/src/niivue/index.ts
+++ b/packages/niivue/src/niivue/index.ts
@@ -1539,19 +1539,16 @@ export class Niivue {
         }
         return mouseConfig.leftButton.primary
       }
-      // Fallback to current behavior
       return ctrlKey ? DRAG_MODE.crosshair : this.opts.dragModePrimary
     } else if (button === RIGHT_MOUSE_BUTTON) {
       if (mouseConfig?.rightButton !== undefined) {
         return mouseConfig.rightButton
       }
-      // Fallback to current behavior
       return this.opts.dragMode
     } else if (button === CENTER_MOUSE_BUTTON) {
       if (mouseConfig?.centerButton !== undefined) {
         return mouseConfig.centerButton
       }
-      // Fallback to current behavior
       return this.opts.dragMode
     }
 

--- a/packages/niivue/src/niivue/index.ts
+++ b/packages/niivue/src/niivue/index.ts
@@ -1790,7 +1790,10 @@ export class Niivue {
     const wasCenterDown = this.uiData.mouseButtonCenterDown
     this.uiData.mouseButtonCenterDown = false
     this.uiData.mouseButtonLeftDown = false
-    this.clearActiveDragMode()
+    
+    // Save current drag mode for logic that depends on it
+    const currentDragMode = this.getCurrentDragMode()
+    
     if (this.drawPenFillPts.length > 0) {
       this.drawPenFilled()
     }
@@ -1803,7 +1806,7 @@ export class Niivue {
       this.uiData.isDragging = false
 
       // Handle angle measurement workflow
-      if (this.getCurrentDragMode() === DRAG_MODE.angle) {
+      if (currentDragMode === DRAG_MODE.angle) {
         if (this.uiData.angleState === 'drawing_first_line') {
           // First line completed, save it and start drawing second line
           this.uiData.angleFirstLine = [
@@ -1820,34 +1823,40 @@ export class Niivue {
         } else if (this.uiData.angleState === 'drawing_second_line') {
           // Second line completed, finish angle measurement
           this.uiData.angleState = 'complete'
+          this.clearActiveDragMode()
           this.drawScene()
           return
         }
       }
 
-      if (this.getCurrentDragMode() === DRAG_MODE.callbackOnly) {
+      if (currentDragMode === DRAG_MODE.callbackOnly) {
         this.drawScene()
       } // hide selectionbox
       const fracStart = this.canvasPos2frac([this.uiData.dragStart[0], this.uiData.dragStart[1]])
       const fracEnd = this.canvasPos2frac([this.uiData.dragEnd[0], this.uiData.dragEnd[1]])
       this.generateMouseUpCallback(fracStart, fracEnd)
       // if roiSelection drag mode
-      if (this.getCurrentDragMode() === DRAG_MODE.roiSelection) {
+      if (currentDragMode === DRAG_MODE.roiSelection) {
         // do not call drawScene so that the selection box remains visible
+        this.clearActiveDragMode()
         return
       }
-      if (this.getCurrentDragMode() !== DRAG_MODE.contrast) {
+      if (currentDragMode !== DRAG_MODE.contrast) {
+        this.clearActiveDragMode()
         return
       }
       if (wasCenterDown) {
+        this.clearActiveDragMode()
         return
       }
       if (this.uiData.dragStart[0] === this.uiData.dragEnd[0] && this.uiData.dragStart[1] === this.uiData.dragEnd[1]) {
+        this.clearActiveDragMode()
         return
       }
       this.calculateNewRange({ volIdx: 0 })
       this.refreshLayers(this.volumes[0], 0)
     }
+    this.clearActiveDragMode()
     this.drawScene()
   }
 

--- a/packages/niivue/src/niivue/index.ts
+++ b/packages/niivue/src/niivue/index.ts
@@ -81,8 +81,7 @@ import {
   Scene,
   SLICE_TYPE,
   SHOW_RENDER,
-  DRAG_MODE, // DRAG_MODE_SECONDARY is the same as DRAG_MODE. DRAG_MODE may be deprecated.
-  DRAG_MODE_PRIMARY,
+  DRAG_MODE,
   COLORMAP_TYPE,
   MULTIPLANAR_TYPE,
   DEFAULT_OPTIONS,
@@ -325,9 +324,9 @@ type UIData = {
   dpr?: number
   max2D?: number
   max3D?: number
-  windowX: number // used to track mouse position for DRAG_MODE_PRIMARY.windowing
-  windowY: number // used to track mouse position for DRAG_MODE_PRIMARY.windowing
-  activeDragMode: DRAG_MODE_PRIMARY | DRAG_MODE | null // currently active drag mode during interaction
+  windowX: number // used to track mouse position for DRAG_MODE.windowing
+  windowY: number // used to track mouse position for DRAG_MODE.windowing
+  activeDragMode: DRAG_MODE | null // currently active drag mode during interaction
   activeDragButton: number | null // mouse button that initiated the current drag
   // angle measurement state
   angleFirstLine: number[] // [x1, y1, x2, y2] for first line
@@ -1527,7 +1526,7 @@ export class Niivue {
    * Gets the appropriate drag mode for a mouse button based on configuration.
    * @internal
    */
-  getMouseButtonDragMode(button: number, shiftKey: boolean, ctrlKey: boolean): DRAG_MODE_PRIMARY | DRAG_MODE {
+  getMouseButtonDragMode(button: number, shiftKey: boolean, ctrlKey: boolean): DRAG_MODE {
     const mouseConfig = this.opts.mouseEventConfig
 
     if (button === LEFT_MOUSE_BUTTON) {
@@ -1541,19 +1540,19 @@ export class Niivue {
         return mouseConfig.leftButton.primary
       }
       // Fallback to current behavior
-      return ctrlKey ? DRAG_MODE_PRIMARY.crosshair : this.opts.dragModePrimary
+      return ctrlKey ? DRAG_MODE.crosshair : this.opts.dragModePrimary
     } else if (button === RIGHT_MOUSE_BUTTON) {
       if (mouseConfig?.rightButton !== undefined) {
         return mouseConfig.rightButton
       }
-      // Fallback to current behavior - cast to DRAG_MODE for compatibility
-      return this.opts.dragMode as DRAG_MODE
+      // Fallback to current behavior
+      return this.opts.dragMode
     } else if (button === CENTER_MOUSE_BUTTON) {
       if (mouseConfig?.centerButton !== undefined) {
         return mouseConfig.centerButton
       }
-      // Fallback to current behavior - cast to DRAG_MODE for compatibility
-      return this.opts.dragMode as DRAG_MODE
+      // Fallback to current behavior
+      return this.opts.dragMode
     }
 
     return this.opts.dragMode as DRAG_MODE
@@ -1563,11 +1562,11 @@ export class Niivue {
    * Gets the appropriate drag mode for touch events based on configuration.
    * @internal
    */
-  getTouchDragMode(isDoubleTouch: boolean): DRAG_MODE_PRIMARY | DRAG_MODE {
+  getTouchDragMode(isDoubleTouch: boolean): DRAG_MODE {
     const touchConfig = this.opts.touchEventConfig
 
     if (isDoubleTouch) {
-      return touchConfig?.doubleTouch ?? (this.opts.dragMode as DRAG_MODE)
+      return touchConfig?.doubleTouch ?? this.opts.dragMode
     }
 
     return touchConfig?.singleTouch ?? this.opts.dragModePrimary
@@ -1586,12 +1585,12 @@ export class Niivue {
    * Gets the currently active drag mode, or falls back to configured defaults.
    * @internal
    */
-  getCurrentDragMode(): DRAG_MODE_PRIMARY | DRAG_MODE {
+  getCurrentDragMode(): DRAG_MODE {
     if (this.uiData.activeDragMode !== null) {
       return this.uiData.activeDragMode
     }
     // Fallback to right-click mode for backward compatibility
-    return this.opts.dragMode as DRAG_MODE
+    return this.opts.dragMode
   }
 
   /**
@@ -1607,15 +1606,15 @@ export class Niivue {
    * Unified handler for mouse actions based on drag mode.
    * @internal
    */
-  handleMouseAction(dragMode: DRAG_MODE_PRIMARY | DRAG_MODE, e: MouseEvent, pos: { x: number; y: number }): void {
-    if (dragMode === DRAG_MODE_PRIMARY.crosshair) {
+  handleMouseAction(dragMode: DRAG_MODE, e: MouseEvent, pos: { x: number; y: number }): void {
+    if (dragMode === DRAG_MODE.crosshair) {
       this.mouseDown(pos.x, pos.y)
       this.mouseClick(pos.x, pos.y)
-    } else if (dragMode === DRAG_MODE_PRIMARY.windowing) {
+    } else if (dragMode === DRAG_MODE.windowing) {
       this.uiData.windowX = e.x
       this.uiData.windowY = e.y
     } else {
-      // Handle secondary drag modes (contrast, measurement, pan, etc.)
+      // Handle all other drag modes (contrast, measurement, pan, etc.)
       this.mousePos = [pos.x * this.uiData.dpr!, pos.y * this.uiData.dpr!]
 
       if (dragMode === DRAG_MODE.none) {
@@ -1845,7 +1844,10 @@ export class Niivue {
           this.clearActiveDragMode()
           return
         }
-        if (this.uiData.dragStart[0] === this.uiData.dragEnd[0] && this.uiData.dragStart[1] === this.uiData.dragEnd[1]) {
+        if (
+          this.uiData.dragStart[0] === this.uiData.dragEnd[0] &&
+          this.uiData.dragStart[1] === this.uiData.dragEnd[1]
+        ) {
           this.clearActiveDragMode()
           return
         }
@@ -2057,13 +2059,13 @@ export class Niivue {
       // Use the active drag mode to determine how to handle mouse movement
       const activeDragMode = this.getCurrentDragMode()
 
-      if (activeDragMode === DRAG_MODE_PRIMARY.crosshair) {
+      if (activeDragMode === DRAG_MODE.crosshair) {
         this.mouseMove(pos.x, pos.y)
         this.mouseClick(pos.x, pos.y)
-      } else if (activeDragMode === DRAG_MODE_PRIMARY.windowing) {
-        this.windowingHandler(e.x, e.y)
+      } else if (activeDragMode === DRAG_MODE.windowing) {
+        this.windowingHandler(pos.x, pos.y)
       } else {
-        // Handle all secondary drag modes that need drag tracking
+        // Handle all other drag modes that need drag tracking
         this.setDragEnd(pos.x, pos.y)
       }
 
@@ -2209,10 +2211,10 @@ export class Niivue {
         return
       }
       const dragMode = this.getTouchDragMode(false)
-      if (dragMode === DRAG_MODE_PRIMARY.crosshair) {
+      if (dragMode === DRAG_MODE.crosshair) {
         this.mouseClick(e.touches[0].clientX - rect.left, e.touches[0].clientY - rect.top)
         this.mouseMove(e.touches[0].clientX - rect.left, e.touches[0].clientY - rect.top)
-      } else if (dragMode === DRAG_MODE_PRIMARY.windowing) {
+      } else if (dragMode === DRAG_MODE.windowing) {
         this.windowingHandler(e.touches[0].pageX, e.touches[0].pageY)
         this.drawScene()
       }
@@ -10396,11 +10398,11 @@ export class Niivue {
    * ```js
    * nv.setMouseEventConfig({
    *   leftButton: {
-   *     primary: DRAG_MODE_PRIMARY.windowing,
+   *     primary: DRAG_MODE.windowing,
    *     withShift: DRAG_MODE.measurement,
-   *     withCtrl: DRAG_MODE_PRIMARY.crosshair
+   *     withCtrl: DRAG_MODE.crosshair
    *   },
-   *   rightButton: DRAG_MODE_PRIMARY.crosshair,
+   *   rightButton: DRAG_MODE.crosshair,
    *   centerButton: DRAG_MODE.pan
    * })
    * ```
@@ -10417,7 +10419,7 @@ export class Niivue {
    * @example
    * ```js
    * nv.setTouchEventConfig({
-   *   singleTouch: DRAG_MODE_PRIMARY.windowing,
+   *   singleTouch: DRAG_MODE.windowing,
    *   doubleTouch: DRAG_MODE.pan
    * })
    * ```
@@ -14265,11 +14267,8 @@ export class Niivue {
         return
       }
       // Only draw selection box for specific drag modes that need it
-      if (
-        this.getCurrentDragMode() === DRAG_MODE.contrast ||
-        this.getCurrentDragMode() === DRAG_MODE.roiSelection ||
-        this.getCurrentDragMode() === DRAG_MODE.callbackOnly
-      ) {
+      const currentDragMode = this.getCurrentDragMode()
+      if (currentDragMode === DRAG_MODE.contrast || currentDragMode === DRAG_MODE.roiSelection) {
         const width = Math.abs(this.uiData.dragStart[0] - this.uiData.dragEnd[0])
         const height = Math.abs(this.uiData.dragStart[1] - this.uiData.dragEnd[1])
         this.drawSelectionBox([

--- a/packages/niivue/src/niivue/index.ts
+++ b/packages/niivue/src/niivue/index.ts
@@ -87,7 +87,9 @@ import {
   MULTIPLANAR_TYPE,
   DEFAULT_OPTIONS,
   ExportDocumentData,
-  INITIAL_SCENE_DATA
+  INITIAL_SCENE_DATA,
+  MouseEventConfig,
+  TouchEventConfig
 } from '../nvdocument.js'
 
 import {
@@ -325,6 +327,8 @@ type UIData = {
   max3D?: number
   windowX: number // used to track mouse position for DRAG_MODE_PRIMARY.windowing
   windowY: number // used to track mouse position for DRAG_MODE_PRIMARY.windowing
+  activeDragMode: DRAG_MODE_PRIMARY | DRAG_MODE | null // currently active drag mode during interaction
+  activeDragButton: number | null // mouse button that initiated the current drag
   // angle measurement state
   angleFirstLine: number[] // [x1, y1, x2, y2] for first line
   angleState: 'none' | 'drawing_first_line' | 'drawing_second_line' | 'complete'
@@ -497,6 +501,8 @@ export class Niivue {
     multiTouchGesture: false,
     windowX: 0,
     windowY: 0,
+    activeDragMode: null,
+    activeDragButton: null,
     angleFirstLine: [0.0, 0.0, 0.0, 0.0],
     angleState: 'none'
   }
@@ -1500,88 +1506,144 @@ export class Niivue {
     // respond to different types of mouse clicks
     if (e.button === LEFT_MOUSE_BUTTON && e.shiftKey) {
       this.uiData.mouseButtonCenterDown = true
-      this.mouseCenterButtonHandler(e)
+      this.setActiveDragMode(LEFT_MOUSE_BUTTON, true, e.ctrlKey)
+      this.handleMouseAction(this.uiData.activeDragMode!, e, pos)
     } else if (e.button === LEFT_MOUSE_BUTTON) {
       this.uiData.mouseButtonLeftDown = true
-      this.mouseLeftButtonHandler(e)
+      this.setActiveDragMode(LEFT_MOUSE_BUTTON, false, e.ctrlKey)
+      this.handleMouseAction(this.uiData.activeDragMode!, e, pos)
     } else if (e.button === RIGHT_MOUSE_BUTTON) {
       this.uiData.mouseButtonRightDown = true
-      this.mouseRightButtonHandler(e)
+      this.setActiveDragMode(RIGHT_MOUSE_BUTTON, e.shiftKey, e.ctrlKey)
+      this.handleMouseAction(this.uiData.activeDragMode!, e, pos)
     } else if (e.button === CENTER_MOUSE_BUTTON) {
       this.uiData.mouseButtonCenterDown = true
-      this.mouseCenterButtonHandler(e)
+      this.setActiveDragMode(CENTER_MOUSE_BUTTON, e.shiftKey, e.ctrlKey)
+      this.handleMouseAction(this.uiData.activeDragMode!, e, pos)
     }
   }
 
+
   /**
-   * Handles left mouse button actions for crosshair or windowing mode.
+   * Gets the appropriate drag mode for a mouse button based on configuration.
    * @internal
    */
-  mouseLeftButtonHandler(e: MouseEvent): void {
-    // need to check for control key here in case the user want to override the drag mode
-    if (e.ctrlKey || this.opts.dragModePrimary === DRAG_MODE_PRIMARY.crosshair) {
-      const pos = this.getNoPaddingNoBorderCanvasRelativeMousePosition(e, this.gl.canvas)
-      this.mouseDown(pos!.x, pos!.y)
-      this.mouseClick(pos!.x, pos!.y)
-    } else if (this.opts.dragModePrimary === DRAG_MODE_PRIMARY.windowing) {
-      // save the state of the x and y mouse coordinates for the next comparison on mouse move
+  getMouseButtonDragMode(button: number, shiftKey: boolean, ctrlKey: boolean): DRAG_MODE_PRIMARY | DRAG_MODE {
+    const mouseConfig = this.opts.mouseEventConfig
+    
+    if (button === LEFT_MOUSE_BUTTON) {
+      if (mouseConfig?.leftButton) {
+        if (shiftKey && mouseConfig.leftButton.withShift !== undefined) {
+          return mouseConfig.leftButton.withShift
+        }
+        if (ctrlKey && mouseConfig.leftButton.withCtrl !== undefined) {
+          return mouseConfig.leftButton.withCtrl
+        }
+        return mouseConfig.leftButton.primary
+      }
+      // Fallback to current behavior
+      return ctrlKey ? DRAG_MODE_PRIMARY.crosshair : this.opts.dragModePrimary
+    } else if (button === RIGHT_MOUSE_BUTTON) {
+      if (mouseConfig?.rightButton !== undefined) {
+        return mouseConfig.rightButton
+      }
+      // Fallback to current behavior - cast to DRAG_MODE for compatibility
+      return this.opts.dragMode as DRAG_MODE
+    } else if (button === CENTER_MOUSE_BUTTON) {
+      if (mouseConfig?.centerButton !== undefined) {
+        return mouseConfig.centerButton
+      }
+      // Fallback to current behavior - cast to DRAG_MODE for compatibility
+      return this.opts.dragMode as DRAG_MODE
+    }
+    
+    return this.opts.dragMode as DRAG_MODE
+  }
+
+  /**
+   * Gets the appropriate drag mode for touch events based on configuration.
+   * @internal
+   */
+  getTouchDragMode(isDoubleTouch: boolean): DRAG_MODE_PRIMARY | DRAG_MODE {
+    const touchConfig = this.opts.touchEventConfig
+    
+    if (isDoubleTouch) {
+      return touchConfig?.doubleTouch ?? (this.opts.dragMode as DRAG_MODE)
+    }
+    
+    return touchConfig?.singleTouch ?? this.opts.dragModePrimary
+  }
+
+  /**
+   * Sets the active drag mode for the current interaction.
+   * @internal
+   */
+  setActiveDragMode(button: number, shiftKey: boolean, ctrlKey: boolean): void {
+    this.uiData.activeDragMode = this.getMouseButtonDragMode(button, shiftKey, ctrlKey)
+    this.uiData.activeDragButton = button
+  }
+
+  /**
+   * Gets the currently active drag mode, or falls back to configured defaults.
+   * @internal
+   */
+  getCurrentDragMode(): DRAG_MODE_PRIMARY | DRAG_MODE {
+    if (this.uiData.activeDragMode !== null) {
+      return this.uiData.activeDragMode
+    }
+    // Fallback to right-click mode for backward compatibility
+    return this.opts.dragMode as DRAG_MODE
+  }
+
+  /**
+   * Clears the active drag mode.
+   * @internal
+   */
+  clearActiveDragMode(): void {
+    this.uiData.activeDragMode = null
+    this.uiData.activeDragButton = null
+  }
+
+  /**
+   * Unified handler for mouse actions based on drag mode.
+   * @internal
+   */
+  handleMouseAction(dragMode: DRAG_MODE_PRIMARY | DRAG_MODE, e: MouseEvent, pos: { x: number; y: number }): void {
+    if (dragMode === DRAG_MODE_PRIMARY.crosshair) {
+      this.mouseDown(pos.x, pos.y)
+      this.mouseClick(pos.x, pos.y)
+    } else if (dragMode === DRAG_MODE_PRIMARY.windowing) {
       this.uiData.windowX = e.x
       this.uiData.windowY = e.y
-    }
-  }
-
-  /**
-   * Handles center mouse button drag to initiate 2D panning or clip plane adjustment.
-   * @internal
-   */
-  mouseCenterButtonHandler(e: MouseEvent): void {
-    const pos = this.getNoPaddingNoBorderCanvasRelativeMousePosition(e, this.gl.canvas)
-    this.mousePos = [pos!.x * this.uiData.dpr!, pos!.y * this.uiData.dpr!]
-    if (this.opts.dragMode === DRAG_MODE.none) {
-      return
-    }
-    this.setDragStart(pos!.x, pos!.y)
-    if (!this.uiData.isDragging) {
-      this.uiData.pan2DxyzmmAtMouseDown = vec4.clone(this.scene.pan2Dxyzmm)
-    }
-    this.uiData.isDragging = true
-    this.uiData.dragClipPlaneStartDepthAziElev = this.scene.clipPlaneDepthAziElev
-  }
-
-  /**
-   * Handles right mouse button drag to enable 2D panning or clip plane control.
-   * @internal
-   */
-  mouseRightButtonHandler(e: MouseEvent): void {
-    // this.uiData.isDragging = true;
-    const pos = this.getNoPaddingNoBorderCanvasRelativeMousePosition(e, this.gl.canvas)
-    this.mousePos = [pos!.x * this.uiData.dpr!, pos!.y * this.uiData.dpr!]
-    if (this.opts.dragMode === DRAG_MODE.none) {
-      return
-    }
-
-    // Initialize angle measurement
-    if (this.opts.dragMode === DRAG_MODE.angle) {
-      if (this.uiData.angleState === 'none') {
-        this.uiData.angleState = 'drawing_first_line'
-      } else if (this.uiData.angleState === 'drawing_second_line') {
-        // Handle final click for angle measurement - complete the angle
-        this.uiData.angleState = 'complete'
-        this.drawScene()
+    } else {
+      // Handle secondary drag modes (contrast, measurement, pan, etc.)
+      this.mousePos = [pos.x * this.uiData.dpr!, pos.y * this.uiData.dpr!]
+      
+      if (dragMode === DRAG_MODE.none) {
         return
-      } else if (this.uiData.angleState === 'complete') {
-        // Reset angle measurement if clicking again
-        this.resetAngleMeasurement()
-        this.uiData.angleState = 'drawing_first_line'
       }
-    }
 
-    this.setDragStart(pos!.x, pos!.y)
-    if (!this.uiData.isDragging) {
-      this.uiData.pan2DxyzmmAtMouseDown = vec4.clone(this.scene.pan2Dxyzmm)
+      // Initialize angle measurement
+      if (dragMode === DRAG_MODE.angle) {
+        if (this.uiData.angleState === 'none') {
+          this.uiData.angleState = 'drawing_first_line'
+        } else if (this.uiData.angleState === 'drawing_second_line') {
+          this.uiData.angleState = 'complete'
+          this.drawScene()
+          return
+        } else if (this.uiData.angleState === 'complete') {
+          this.resetAngleMeasurement()
+          this.uiData.angleState = 'drawing_first_line'
+        }
+      }
+
+      this.setDragStart(pos.x, pos.y)
+      if (!this.uiData.isDragging) {
+        this.uiData.pan2DxyzmmAtMouseDown = vec4.clone(this.scene.pan2Dxyzmm)
+      }
+      this.uiData.isDragging = true
+      this.uiData.dragClipPlaneStartDepthAziElev = this.scene.clipPlaneDepthAziElev
     }
-    this.uiData.isDragging = true
-    this.uiData.dragClipPlaneStartDepthAziElev = this.scene.clipPlaneDepthAziElev
   }
 
   /**
@@ -1728,6 +1790,7 @@ export class Niivue {
     const wasCenterDown = this.uiData.mouseButtonCenterDown
     this.uiData.mouseButtonCenterDown = false
     this.uiData.mouseButtonLeftDown = false
+    this.clearActiveDragMode()
     if (this.drawPenFillPts.length > 0) {
       this.drawPenFilled()
     }
@@ -1740,7 +1803,7 @@ export class Niivue {
       this.uiData.isDragging = false
 
       // Handle angle measurement workflow
-      if (this.opts.dragMode === DRAG_MODE.angle) {
+      if (this.getCurrentDragMode() === DRAG_MODE.angle) {
         if (this.uiData.angleState === 'drawing_first_line') {
           // First line completed, save it and start drawing second line
           this.uiData.angleFirstLine = [
@@ -1762,18 +1825,18 @@ export class Niivue {
         }
       }
 
-      if (this.opts.dragMode === DRAG_MODE.callbackOnly) {
+      if (this.getCurrentDragMode() === DRAG_MODE.callbackOnly) {
         this.drawScene()
       } // hide selectionbox
       const fracStart = this.canvasPos2frac([this.uiData.dragStart[0], this.uiData.dragStart[1]])
       const fracEnd = this.canvasPos2frac([this.uiData.dragEnd[0], this.uiData.dragEnd[1]])
       this.generateMouseUpCallback(fracStart, fracEnd)
       // if roiSelection drag mode
-      if (this.opts.dragMode === DRAG_MODE.roiSelection) {
+      if (this.getCurrentDragMode() === DRAG_MODE.roiSelection) {
         // do not call drawScene so that the selection box remains visible
         return
       }
-      if (this.opts.dragMode !== DRAG_MODE.contrast) {
+      if (this.getCurrentDragMode() !== DRAG_MODE.contrast) {
         return
       }
       if (wasCenterDown) {
@@ -1856,7 +1919,7 @@ export class Niivue {
     if (this.uiData.isDragging) {
       this.uiData.isDragging = false
       // if drag mode is contrast, and the user double taps and drags...
-      if (this.opts.dragMode === DRAG_MODE.contrast) {
+      if (this.getCurrentDragMode() === DRAG_MODE.contrast) {
         this.calculateNewRange()
         this.refreshLayers(this.volumes[0], 0)
       }
@@ -1984,23 +2047,24 @@ export class Niivue {
       if (tile !== this.uiData.clickedTile) {
         return
       }
-      if (this.uiData.mouseButtonLeftDown) {
-        const isCrosshairMode = this.opts.dragModePrimary === DRAG_MODE_PRIMARY.crosshair
-        const isWindowingMode = this.opts.dragModePrimary === DRAG_MODE_PRIMARY.windowing
-        const ctrlKey = e.ctrlKey
-        if (ctrlKey || isCrosshairMode) {
-          this.mouseMove(pos.x, pos.y)
-          this.mouseClick(pos.x, pos.y)
-        } else if (isWindowingMode) {
-          this.windowingHandler(e.x, e.y)
-        }
-      } else if (this.uiData.mouseButtonRightDown || this.uiData.mouseButtonCenterDown) {
+      
+      // Use the active drag mode to determine how to handle mouse movement
+      const activeDragMode = this.getCurrentDragMode()
+      
+      if (activeDragMode === DRAG_MODE_PRIMARY.crosshair) {
+        this.mouseMove(pos.x, pos.y)
+        this.mouseClick(pos.x, pos.y)
+      } else if (activeDragMode === DRAG_MODE_PRIMARY.windowing) {
+        this.windowingHandler(e.x, e.y)
+      } else {
+        // Handle all secondary drag modes that need drag tracking
         this.setDragEnd(pos.x, pos.y)
       }
+      
       this.drawScene()
       this.uiData.prevX = this.uiData.currX
       this.uiData.prevY = this.uiData.currY
-    } else if (this.opts.dragMode === DRAG_MODE.angle && this.uiData.angleState === 'drawing_second_line') {
+    } else if (this.getCurrentDragMode() === DRAG_MODE.angle && this.uiData.angleState === 'drawing_second_line') {
       // Handle angle measurement second line tracking
       const pos = this.getNoPaddingNoBorderCanvasRelativeMousePosition(e, this.gl.canvas)
       if (!pos) {
@@ -2081,7 +2145,7 @@ export class Niivue {
       this.drawScene() // this duplicate drawScene is necessary for depth picking. DO NOT REMOVE
       return
     }
-    if (this.opts.dragMode === DRAG_MODE.slicer3D) {
+    if (this.getCurrentDragMode() === DRAG_MODE.slicer3D) {
       return
     }
     if (this.volumes.length < 1) {
@@ -2138,12 +2202,11 @@ export class Niivue {
         this.drawScene()
         return
       }
-      const isCrosshairMode = this.opts.dragModePrimary === DRAG_MODE_PRIMARY.crosshair
-      const isWindowingMode = this.opts.dragModePrimary === DRAG_MODE_PRIMARY.windowing
-      if (isCrosshairMode) {
+      const dragMode = this.getTouchDragMode(false)
+      if (dragMode === DRAG_MODE_PRIMARY.crosshair) {
         this.mouseClick(e.touches[0].clientX - rect.left, e.touches[0].clientY - rect.top)
         this.mouseMove(e.touches[0].clientX - rect.left, e.touches[0].clientY - rect.top)
-      } else if (isWindowingMode) {
+      } else if (dragMode === DRAG_MODE_PRIMARY.windowing) {
         this.windowingHandler(e.touches[0].pageX, e.touches[0].pageY)
         this.drawScene()
       }
@@ -2288,7 +2351,7 @@ export class Niivue {
     const dragStartSum = this.uiData.dragStart.reduce((a, b) => a + b, 0)
     const dragEndSum = this.uiData.dragEnd.reduce((a, b) => a + b, 0)
     const validDrag = dragStartSum > 0 && dragEndSum > 0
-    if (this.opts.dragMode === DRAG_MODE.roiSelection && validDrag) {
+    if (this.getCurrentDragMode() === DRAG_MODE.roiSelection && validDrag) {
       const delta = e.deltaY > 0 ? 1 : -1
       // update the uiData.dragStart and uiData.dragEnd values to grow or shrink the selection box
       if (this.uiData.dragStart[0] < this.uiData.dragEnd[0]) {
@@ -2360,7 +2423,7 @@ export class Niivue {
     const x = e.clientX - rect.left
     const y = e.clientY - rect.top
 
-    if (this.opts.dragMode === DRAG_MODE.pan && this.inRenderTile(this.uiData.dpr! * x, this.uiData.dpr! * y) === -1) {
+    if (this.getCurrentDragMode() === DRAG_MODE.pan && this.inRenderTile(this.uiData.dpr! * x, this.uiData.dpr! * y) === -1) {
       // Zoom
       const zoomDirection = scrollAmount < 0 ? 1 : -1
       let zoom = this.scene.pan2Dxyzmm[3] * (1.0 + 10 * (0.01 * zoomDirection))
@@ -10313,6 +10376,63 @@ export class Niivue {
     if (this.opts.dragMode !== DRAG_MODE.angle) {
       this.resetAngleMeasurement()
     }
+    // Clear active drag mode since we're changing the configuration
+    this.clearActiveDragMode()
+  }
+
+  /**
+   * Set custom mouse event configuration for button mappings.
+   * @param config - Mouse event configuration object
+   * @example
+   * ```js
+   * nv.setMouseEventConfig({
+   *   leftButton: {
+   *     primary: DRAG_MODE_PRIMARY.windowing,
+   *     withShift: DRAG_MODE.measurement,
+   *     withCtrl: DRAG_MODE_PRIMARY.crosshair
+   *   },
+   *   rightButton: DRAG_MODE_PRIMARY.crosshair,
+   *   centerButton: DRAG_MODE.pan
+   * })
+   * ```
+   */
+  setMouseEventConfig(config: MouseEventConfig): void {
+    this.opts.mouseEventConfig = config
+    // Clear active drag mode since we're changing the configuration
+    this.clearActiveDragMode()
+  }
+
+  /**
+   * Set custom touch event configuration for touch gesture mappings.
+   * @param config - Touch event configuration object
+   * @example
+   * ```js
+   * nv.setTouchEventConfig({
+   *   singleTouch: DRAG_MODE_PRIMARY.windowing,
+   *   doubleTouch: DRAG_MODE.pan
+   * })
+   * ```
+   */
+  setTouchEventConfig(config: TouchEventConfig): void {
+    this.opts.touchEventConfig = config
+    // Clear active drag mode since we're changing the configuration
+    this.clearActiveDragMode()
+  }
+
+  /**
+   * Get current mouse event configuration.
+   * @returns Current mouse event configuration or undefined if using defaults
+   */
+  getMouseEventConfig(): MouseEventConfig | undefined {
+    return this.opts.mouseEventConfig
+  }
+
+  /**
+   * Get current touch event configuration.
+   * @returns Current touch event configuration or undefined if using defaults
+   */
+  getTouchEventConfig(): TouchEventConfig | undefined {
+    return this.opts.touchEventConfig
   }
 
   /**
@@ -10397,7 +10517,7 @@ export class Niivue {
    * @internal
    */
   drawSelectionBox(leftTopWidthHeight: number[]): void {
-    if (this.opts.dragMode === DRAG_MODE.roiSelection) {
+    if (this.getCurrentDragMode() === DRAG_MODE.roiSelection) {
       this.drawCircle(leftTopWidthHeight, this.opts.selectionBoxColor, 0.1)
       return
     }
@@ -14100,7 +14220,7 @@ export class Niivue {
         ])
         return
       }
-      if (this.opts.dragMode === DRAG_MODE.slicer3D) {
+      if (this.getCurrentDragMode() === DRAG_MODE.slicer3D) {
         this.dragForSlicer3D([
           this.uiData.dragStart[0],
           this.uiData.dragStart[1],
@@ -14109,7 +14229,7 @@ export class Niivue {
         ])
         return
       }
-      if (this.opts.dragMode === DRAG_MODE.pan) {
+      if (this.getCurrentDragMode() === DRAG_MODE.pan) {
         this.dragForPanZoom([
           this.uiData.dragStart[0],
           this.uiData.dragStart[1],
@@ -14121,7 +14241,7 @@ export class Niivue {
       if (this.inRenderTile(this.uiData.dragStart[0], this.uiData.dragStart[1]) >= 0) {
         return
       }
-      if (this.opts.dragMode === DRAG_MODE.measurement) {
+      if (this.getCurrentDragMode() === DRAG_MODE.measurement) {
         // if (this.opts.isDragShowsMeasurementTool) {
         this.drawMeasurementTool([
           this.uiData.dragStart[0],
@@ -14131,7 +14251,7 @@ export class Niivue {
         ])
         return
       }
-      if (this.opts.dragMode === DRAG_MODE.angle) {
+      if (this.getCurrentDragMode() === DRAG_MODE.angle) {
         this.drawAngleMeasurementTool()
         return
       }

--- a/packages/niivue/src/niivue/index.ts
+++ b/packages/niivue/src/niivue/index.ts
@@ -331,6 +331,15 @@ type UIData = {
   // angle measurement state
   angleFirstLine: number[] // [x1, y1, x2, y2] for first line
   angleState: 'none' | 'drawing_first_line' | 'drawing_second_line' | 'complete'
+  // persistent measurement and angle state
+  completedMeasurements: Array<{ line: number[]; sliceIndex: number; sliceType: SLICE_TYPE; slicePosition: number }> // array of measurement lines with slice info
+  completedAngles: Array<{
+    firstLine: number[]
+    secondLine: number[]
+    sliceIndex: number
+    sliceType: SLICE_TYPE
+    slicePosition: number
+  }> // array of completed angles with slice info
 }
 
 type SaveImageOptions = {
@@ -503,7 +512,9 @@ export class Niivue {
     activeDragMode: null,
     activeDragButton: null,
     angleFirstLine: [0.0, 0.0, 0.0, 0.0],
-    angleState: 'none'
+    angleState: 'none',
+    completedMeasurements: [],
+    completedAngles: []
   }
 
   back: NVImage | null = null // base layer; defines image space to work in. Defined as this.volumes[0] in Niivue.loadVolumes
@@ -1595,8 +1606,15 @@ export class Niivue {
    * @internal
    */
   clearActiveDragMode(): void {
+    console.log('DEBUG: clearActiveDragMode called')
+    console.log('DEBUG: activeDragMode before clear:', this.uiData.activeDragMode)
+    console.log('DEBUG: angleState at clearActiveDragMode:', this.uiData.angleState)
+    console.log('DEBUG: completedAngles length at clearActiveDragMode:', this.uiData.completedAngles.length)
+
     this.uiData.activeDragMode = null
     this.uiData.activeDragButton = null
+
+    console.log('DEBUG: activeDragMode after clear:', this.uiData.activeDragMode)
   }
 
   /**
@@ -1623,7 +1641,66 @@ export class Niivue {
         if (this.uiData.angleState === 'none') {
           this.uiData.angleState = 'drawing_first_line'
         } else if (this.uiData.angleState === 'drawing_second_line') {
+          // Final click - save completed angle with slice info
+          console.log('DEBUG: Final angle click - angleState is drawing_second_line')
+          console.log('DEBUG: dragEnd position:', this.uiData.dragEnd)
+          console.log('DEBUG: angleFirstLine:', this.uiData.angleFirstLine)
+          console.log('DEBUG: current click position:', pos.x, pos.y)
+
+          // Use current click position instead of dragEnd for final position
+          const finalClickPos = [pos.x * this.uiData.dpr!, pos.y * this.uiData.dpr!]
+          console.log('DEBUG: finalClickPos:', finalClickPos)
+
+          // Get slice info using the current click position
+          const tileIdx = this.tileIndex(finalClickPos[0], finalClickPos[1])
+          console.log('DEBUG: tileIdx for final click:', tileIdx)
+
+          let sliceInfo = { sliceIndex: -1, sliceType: SLICE_TYPE.AXIAL, slicePosition: 0 }
+          if (tileIdx >= 0 && tileIdx < this.screenSlices.length) {
+            const sliceType = this.screenSlices[tileIdx].axCorSag
+            let slicePosition = 0
+
+            // Get the current slice position based on the crosshair position
+            if (sliceType === SLICE_TYPE.AXIAL) {
+              slicePosition = this.scene.crosshairPos[2] // Z coordinate for axial slices
+            } else if (sliceType === SLICE_TYPE.CORONAL) {
+              slicePosition = this.scene.crosshairPos[1] // Y coordinate for coronal slices
+            } else if (sliceType === SLICE_TYPE.SAGITTAL) {
+              slicePosition = this.scene.crosshairPos[0] // X coordinate for sagittal slices
+            }
+
+            sliceInfo = {
+              sliceIndex: tileIdx,
+              sliceType,
+              slicePosition
+            }
+          }
+          console.log('DEBUG: sliceInfo:', sliceInfo)
+
+          const secondLine = [
+            this.uiData.angleFirstLine[2], // start from end of first line
+            this.uiData.angleFirstLine[3],
+            finalClickPos[0], // to final click position
+            finalClickPos[1]
+          ]
+          console.log('DEBUG: secondLine calculated:', secondLine)
+
+          const angleToSave = {
+            firstLine: [...this.uiData.angleFirstLine],
+            secondLine,
+            sliceIndex: sliceInfo.sliceIndex,
+            sliceType: sliceInfo.sliceType,
+            slicePosition: sliceInfo.slicePosition
+          }
+          console.log('DEBUG: angleToSave:', angleToSave)
+
+          this.uiData.completedAngles.push(angleToSave)
+          console.log('DEBUG: completedAngles length after push:', this.uiData.completedAngles.length)
+          console.log('DEBUG: completedAngles array:', this.uiData.completedAngles)
+
+          this.resetAngleMeasurement()
           this.uiData.angleState = 'complete'
+          console.log('DEBUG: angleState set to complete, calling drawScene')
           this.drawScene()
           return
         } else if (this.uiData.angleState === 'complete') {
@@ -1768,6 +1845,12 @@ export class Niivue {
    * @internal
    */
   mouseUpListener(): void {
+    console.log('DEBUG: mouseUpListener called')
+    console.log('DEBUG: angleState at mouseUpListener:', this.uiData.angleState)
+    console.log('DEBUG: isDragging at mouseUpListener:', this.uiData.isDragging)
+    console.log('DEBUG: activeDragMode at mouseUpListener:', this.uiData.activeDragMode)
+    console.log('DEBUG: completedAngles length at mouseUpListener:', this.uiData.completedAngles.length)
+
     function isFunction(test: unknown): boolean {
       return Object.prototype.toString.call(test).indexOf('Function') > -1
     }
@@ -1816,7 +1899,7 @@ export class Niivue {
           this.drawScene()
           return
         } else if (this.uiData.angleState === 'drawing_second_line') {
-          // Second line completed, finish angle measurement
+          // Second line completed, but angle will be saved in mouseDownListener
           this.uiData.angleState = 'complete'
           this.clearActiveDragMode()
           this.drawScene()
@@ -1850,6 +1933,19 @@ export class Niivue {
         }
         this.calculateNewRange({ volIdx: 0 })
         this.refreshLayers(this.volumes[0], 0)
+      }
+      if (currentDragMode === DRAG_MODE.measurement) {
+        // Save completed measurement line with slice info
+        const sliceInfo = this.getCurrentSliceInfo()
+        this.uiData.completedMeasurements.push({
+          line: [this.uiData.dragStart[0], this.uiData.dragStart[1], this.uiData.dragEnd[0], this.uiData.dragEnd[1]],
+          sliceIndex: sliceInfo.sliceIndex,
+          sliceType: sliceInfo.sliceType,
+          slicePosition: sliceInfo.slicePosition
+        })
+        this.clearActiveDragMode()
+        this.drawScene()
+        return
       }
     }
     this.clearActiveDragMode()
@@ -10254,21 +10350,6 @@ export class Niivue {
 
       // Calculate and display angle
       this.drawAngleText()
-    } else if (this.uiData.angleState === 'complete') {
-      // Draw both completed lines
-      this.drawMeasurementTool(this.uiData.angleFirstLine, false)
-
-      // Draw the second line (completed)
-      const secondLine = [
-        this.uiData.angleFirstLine[2], // start from end of first line
-        this.uiData.angleFirstLine[3],
-        this.uiData.dragEnd[0], // to final position
-        this.uiData.dragEnd[1]
-      ]
-      this.drawMeasurementTool(secondLine, false)
-
-      // Calculate and display angle
-      this.drawAngleText()
     }
   }
 
@@ -10293,6 +10374,34 @@ export class Niivue {
     const intersectionY = this.uiData.angleFirstLine[3]
 
     const angleText = `${angle.toFixed(1)}°`
+
+    // Draw angle text at intersection
+    this.drawTextBetween(
+      [intersectionX, intersectionY, intersectionX + 1, intersectionY + 1],
+      angleText,
+      this.opts.measureTextHeight / 0.06,
+      this.opts.measureTextColor
+    )
+  }
+
+  /**
+   * Calculate and draw angle text for a completed angle.
+   * @internal
+   */
+  drawAngleTextForAngle(angle: {
+    firstLine: number[]
+    secondLine: number[]
+    sliceIndex: number
+    sliceType: SLICE_TYPE
+    slicePosition: number
+  }): void {
+    const angle_degrees = this.calculateAngleBetweenLines(angle.firstLine, angle.secondLine)
+
+    // Display angle at intersection point
+    const intersectionX = angle.firstLine[2]
+    const intersectionY = angle.firstLine[3]
+
+    const angleText = `${angle_degrees.toFixed(1)}°`
 
     // Draw angle text at intersection
     this.drawTextBetween(
@@ -10336,8 +10445,138 @@ export class Niivue {
    * @internal
    */
   resetAngleMeasurement(): void {
+    console.log('DEBUG: resetAngleMeasurement called')
+    console.log('DEBUG: angleState before reset:', this.uiData.angleState)
+    console.log('DEBUG: completedAngles length before reset:', this.uiData.completedAngles.length)
+
     this.uiData.angleState = 'none'
     this.uiData.angleFirstLine = [0.0, 0.0, 0.0, 0.0]
+
+    console.log('DEBUG: angleState after reset:', this.uiData.angleState)
+    console.log('DEBUG: completedAngles length after reset:', this.uiData.completedAngles.length)
+  }
+
+  /**
+   * Get slice information for the current measurement/angle.
+   * @internal
+   */
+  getCurrentSliceInfo(): { sliceIndex: number; sliceType: SLICE_TYPE; slicePosition: number } {
+    const tileIdx = this.tileIndex(this.uiData.dragStart[0], this.uiData.dragStart[1])
+    if (tileIdx >= 0 && tileIdx < this.screenSlices.length) {
+      const sliceType = this.screenSlices[tileIdx].axCorSag
+      let slicePosition = 0
+
+      // Get the current slice position based on the crosshair position
+      if (sliceType === SLICE_TYPE.AXIAL) {
+        slicePosition = this.scene.crosshairPos[2] // Z coordinate for axial slices
+      } else if (sliceType === SLICE_TYPE.CORONAL) {
+        slicePosition = this.scene.crosshairPos[1] // Y coordinate for coronal slices
+      } else if (sliceType === SLICE_TYPE.SAGITTAL) {
+        slicePosition = this.scene.crosshairPos[0] // X coordinate for sagittal slices
+      }
+
+      return {
+        sliceIndex: tileIdx,
+        sliceType,
+        slicePosition
+      }
+    }
+    return { sliceIndex: -1, sliceType: SLICE_TYPE.AXIAL, slicePosition: 0 }
+  }
+
+  /**
+   * Check if a measurement/angle should be drawn on the current slice.
+   * @internal
+   */
+  shouldDrawOnCurrentSlice(sliceIndex: number, sliceType: SLICE_TYPE, slicePosition: number): boolean {
+    console.log('DEBUG: shouldDrawOnCurrentSlice called with:', { sliceIndex, sliceType, slicePosition })
+    console.log('DEBUG: current opts.sliceType:', this.opts.sliceType)
+    console.log('DEBUG: current scene.crosshairPos:', this.scene.crosshairPos)
+
+    // First check if the measurement is on the same tile/slice type
+    if (this.opts.sliceType === SLICE_TYPE.MULTIPLANAR) {
+      // If sliceIndex is -1, try to find the corresponding tile by slice type
+      if (sliceIndex < 0) {
+        console.log('DEBUG: sliceIndex is -1, searching for tile by slice type')
+        let foundTile = false
+        for (let i = 0; i < this.screenSlices.length; i++) {
+          if (this.screenSlices[i].axCorSag === sliceType) {
+            console.log('DEBUG: Found tile', i, 'with slice type', sliceType)
+            foundTile = true
+            break
+          }
+        }
+        if (!foundTile) {
+          console.log('DEBUG: No tile found with slice type', sliceType)
+          return false
+        }
+      } else if (sliceIndex >= this.screenSlices.length || this.screenSlices[sliceIndex].axCorSag !== sliceType) {
+        console.log('DEBUG: Returning false - tile/slice type mismatch in multiplanar')
+        return false
+      }
+    } else if (this.opts.sliceType !== sliceType) {
+      console.log('DEBUG: Returning false - slice type mismatch in single slice')
+      return false
+    }
+
+    // Now check if we're on the same slice position
+    let currentSlicePosition = 0
+    if (sliceType === SLICE_TYPE.AXIAL) {
+      currentSlicePosition = this.scene.crosshairPos[2] // Z coordinate for axial slices
+    } else if (sliceType === SLICE_TYPE.CORONAL) {
+      currentSlicePosition = this.scene.crosshairPos[1] // Y coordinate for coronal slices
+    } else if (sliceType === SLICE_TYPE.SAGITTAL) {
+      currentSlicePosition = this.scene.crosshairPos[0] // X coordinate for sagittal slices
+    }
+
+    console.log('DEBUG: currentSlicePosition:', currentSlicePosition)
+    console.log('DEBUG: saved slicePosition:', slicePosition)
+
+    // Use a small tolerance for floating point comparison
+    const tolerance = 0.001
+    const difference = Math.abs(currentSlicePosition - slicePosition)
+    console.log('DEBUG: position difference:', difference)
+    const result = difference < tolerance
+    console.log('DEBUG: shouldDrawOnCurrentSlice result:', result)
+
+    return result
+  }
+
+  /**
+   * Clear all persistent measurement lines from the canvas.
+   * @example
+   * ```js
+   * nv.clearMeasurements()
+   * ```
+   */
+  clearMeasurements(): void {
+    this.uiData.completedMeasurements = []
+    this.drawScene()
+  }
+
+  /**
+   * Clear all persistent angle measurements from the canvas.
+   * @example
+   * ```js
+   * nv.clearAngles()
+   * ```
+   */
+  clearAngles(): void {
+    this.uiData.completedAngles = []
+    this.drawScene()
+  }
+
+  /**
+   * Clear all persistent measurements and angles from the canvas.
+   * @example
+   * ```js
+   * nv.clearAllMeasurements()
+   * ```
+   */
+  clearAllMeasurements(): void {
+    this.uiData.completedMeasurements = []
+    this.uiData.completedAngles = []
+    this.drawScene()
   }
 
   /**
@@ -14257,11 +14496,11 @@ export class Niivue {
           this.uiData.dragEnd[0],
           this.uiData.dragEnd[1]
         ])
-        return
+        // return
       }
       if (this.getCurrentDragMode() === DRAG_MODE.angle) {
         this.drawAngleMeasurementTool()
-        return
+        // return
       }
       // Only draw selection box for specific drag modes that need it
       const currentDragMode = this.getCurrentDragMode()
@@ -14275,7 +14514,34 @@ export class Niivue {
           height
         ])
       }
-      return
+      // return
+    }
+
+    // Draw persistent completed measurements for current slice
+    for (const measurement of this.uiData.completedMeasurements) {
+      if (this.shouldDrawOnCurrentSlice(measurement.sliceIndex, measurement.sliceType, measurement.slicePosition)) {
+        this.drawMeasurementTool(measurement.line)
+      }
+    }
+
+    // Draw persistent completed angles for current slice
+    console.log('DEBUG: Drawing angles, completedAngles length:', this.uiData.completedAngles.length)
+    for (let i = 0; i < this.uiData.completedAngles.length; i++) {
+      const angle = this.uiData.completedAngles[i]
+      console.log(`DEBUG: Checking angle ${i}:`, angle)
+
+      const shouldDraw = this.shouldDrawOnCurrentSlice(angle.sliceIndex, angle.sliceType, angle.slicePosition)
+      console.log(`DEBUG: shouldDrawOnCurrentSlice result for angle ${i}:`, shouldDraw)
+
+      if (shouldDraw) {
+        console.log(`DEBUG: Drawing angle ${i}`)
+        this.drawMeasurementTool(angle.firstLine, false)
+        this.drawMeasurementTool(angle.secondLine, false)
+        // Draw angle text
+        this.drawAngleTextForAngle(angle)
+      } else {
+        console.log(`DEBUG: Skipping angle ${i} - not on current slice`)
+      }
     }
 
     // draw circle at mouse position if clickToSegment is enabled

--- a/packages/niivue/src/nvdocument.ts
+++ b/packages/niivue/src/nvdocument.ts
@@ -67,6 +67,21 @@ export enum DRAG_MODE_PRIMARY {
   windowing = 1
 }
 
+export interface MouseEventConfig {
+  leftButton: {
+    primary: DRAG_MODE_PRIMARY | DRAG_MODE
+    withShift?: DRAG_MODE_PRIMARY | DRAG_MODE
+    withCtrl?: DRAG_MODE_PRIMARY | DRAG_MODE
+  }
+  rightButton: DRAG_MODE_PRIMARY | DRAG_MODE
+  centerButton: DRAG_MODE_PRIMARY | DRAG_MODE
+}
+
+export interface TouchEventConfig {
+  singleTouch: DRAG_MODE_PRIMARY | DRAG_MODE
+  doubleTouch: DRAG_MODE_PRIMARY | DRAG_MODE
+}
+
 export enum COLORMAP_TYPE {
   MIN_TO_MAX = 0,
   ZERO_TO_MAX_TRANSPARENT_BELOW_MIN = 1,
@@ -135,6 +150,8 @@ export type NVConfigOptions = {
   meshThicknessOn2D: number | string
   dragMode: DRAG_MODE | DRAG_MODE_SECONDARY
   dragModePrimary: DRAG_MODE_PRIMARY
+  mouseEventConfig?: MouseEventConfig
+  touchEventConfig?: TouchEventConfig
   yoke3Dto2DZoom: boolean
   isDepthPickMesh: boolean
   isCornerOrientationText: boolean
@@ -252,6 +269,8 @@ export const DEFAULT_OPTIONS: NVConfigOptions = {
   meshThicknessOn2D: Infinity,
   dragMode: DRAG_MODE_SECONDARY.contrast,
   dragModePrimary: DRAG_MODE_PRIMARY.crosshair,
+  mouseEventConfig: undefined,
+  touchEventConfig: undefined,
   yoke3Dto2DZoom: false,
   isDepthPickMesh: false,
   isCornerOrientationText: false,

--- a/packages/niivue/src/nvdocument.ts
+++ b/packages/niivue/src/nvdocument.ts
@@ -48,38 +48,24 @@ export enum DRAG_MODE {
   slicer3D = 4,
   callbackOnly = 5,
   roiSelection = 6,
-  angle = 7
-}
-
-export enum DRAG_MODE_SECONDARY {
-  none = 0,
-  contrast = 1,
-  measurement = 2,
-  pan = 3,
-  slicer3D = 4,
-  callbackOnly = 5,
-  roiSelection = 6,
-  angle = 7
-}
-
-export enum DRAG_MODE_PRIMARY {
-  crosshair = 0,
-  windowing = 1
+  angle = 7,
+  crosshair = 8,
+  windowing = 9
 }
 
 export interface MouseEventConfig {
   leftButton: {
-    primary: DRAG_MODE_PRIMARY | DRAG_MODE
-    withShift?: DRAG_MODE_PRIMARY | DRAG_MODE
-    withCtrl?: DRAG_MODE_PRIMARY | DRAG_MODE
+    primary: DRAG_MODE
+    withShift?: DRAG_MODE
+    withCtrl?: DRAG_MODE
   }
-  rightButton: DRAG_MODE_PRIMARY | DRAG_MODE
-  centerButton: DRAG_MODE_PRIMARY | DRAG_MODE
+  rightButton: DRAG_MODE
+  centerButton: DRAG_MODE
 }
 
 export interface TouchEventConfig {
-  singleTouch: DRAG_MODE_PRIMARY | DRAG_MODE
-  doubleTouch: DRAG_MODE_PRIMARY | DRAG_MODE
+  singleTouch: DRAG_MODE
+  doubleTouch: DRAG_MODE
 }
 
 export enum COLORMAP_TYPE {
@@ -148,8 +134,8 @@ export type NVConfigOptions = {
   isRadiologicalConvention: boolean
   // string to allow infinity
   meshThicknessOn2D: number | string
-  dragMode: DRAG_MODE | DRAG_MODE_SECONDARY
-  dragModePrimary: DRAG_MODE_PRIMARY
+  dragMode: DRAG_MODE
+  dragModePrimary: DRAG_MODE
   mouseEventConfig?: MouseEventConfig
   touchEventConfig?: TouchEventConfig
   yoke3Dto2DZoom: boolean
@@ -267,8 +253,8 @@ export const DEFAULT_OPTIONS: NVConfigOptions = {
   multiplanarShowRender: SHOW_RENDER.AUTO, // auto is the same behaviour as multiplanarForceRender: false
   isRadiologicalConvention: false,
   meshThicknessOn2D: Infinity,
-  dragMode: DRAG_MODE_SECONDARY.contrast,
-  dragModePrimary: DRAG_MODE_PRIMARY.crosshair,
+  dragMode: DRAG_MODE.contrast,
+  dragModePrimary: DRAG_MODE.crosshair,
   mouseEventConfig: undefined,
   touchEventConfig: undefined,
   yoke3Dto2DZoom: false,


### PR DESCRIPTION
This PR implements a configurable system for setting mouse buttons (left and right) to any available DRAG_MODE. This is a breaking change and unifies all mouse actions under a unified DRAG_MODE enum and removes DRAG_MODE_PRIMARY and DRAG_MODE_SECONDARY. 

This PR also implements persistent measurement tracking and angle tracking. This is a WIP and needs changes to make sure we don't draw measurements lines from the multiplanar view if the user has switched to the axial view (as an example). We should also think about the units for storing line measurements in order to save/load them in the future in the most cross device, but interpretable way possible. 

List of fixed issues (if they exist):

- #1365 
- #1363 
