### PR TITLE
[ENH] Quality-of-life enhancements to NVDocument.json()

### DIFF
--- a/packages/niivue/src/nvdocument.ts
+++ b/packages/niivue/src/nvdocument.ts
@@ -801,7 +801,7 @@ export class NVDocument {
             alphaThreshold: false,
             cal_minNeg: volume?.cal_minNeg ?? NaN,
             cal_maxNeg: volume?.cal_maxNeg ?? NaN,
-            colorbarVisible: volume?.colorbarVisible ??true
+            colorbarVisible: volume?.colorbarVisible ?? true
           }
         } else {
           if (!('imageType' in imageOptions)) {

--- a/packages/niivue/src/nvdocument.ts
+++ b/packages/niivue/src/nvdocument.ts
@@ -795,9 +795,8 @@ export class NVDocument {
             imageType: volume?.imageType ?? NVIMAGE_TYPE.NII,
             frame4D: volume?.frame4D ?? 0,
             limitFrames4D: volume?.limitFrames4D ?? NaN,
-            // PW: Assuming url/urlImageData should be none when embedImages is true(?)
-            url: embedImages ? '' : (volume?.url ?? ''),
-            urlImageData: embedImages ? '' : (volume?.urlImgData ?? ''),
+            url: volume?.url ?? '',
+            urlImageData: volume?.urlImgData ?? '',
             alphaThreshold: false,
             cal_minNeg: volume?.cal_minNeg ?? NaN,
             cal_maxNeg: volume?.cal_maxNeg ?? NaN,

--- a/packages/niivue/src/nvdocument.ts
+++ b/packages/niivue/src/nvdocument.ts
@@ -741,8 +741,9 @@ export class NVDocument {
    *
    * @param embedImages  If false, encodedImageBlobs is left empty
    *                     (imageOptionsArray still records the URL / name).
+   * @param embedDrawing  If false, encodedDrawingBlob is left empty
    */
-  json(embedImages = true): ExportDocumentData {
+  json(embedImages = true, embedDrawing = true): ExportDocumentData {
     const data: Partial<ExportDocumentData> = {
       encodedImageBlobs: [],
       previewImageDataURL: this.data.previewImageDataURL,
@@ -776,32 +777,31 @@ export class NVDocument {
       for (let i = 0; i < this.volumes.length; i++) {
         const volume = this.volumes[i]
         let imageOptions = this.getImageOptions(volume)
-
         if (imageOptions === null) {
-          log.warn('no options found for image, using default')
+          log.warn('no options found for image, using options from the volume directly')
           imageOptions = {
-            name: '',
-            colormap: 'gray',
-            opacity: 1.0,
+            name: volume?.name ?? '',
+            colormap: volume?._colormap ?? 'gray',
+            opacity: volume?._opacity ?? 1.0,
             pairedImgData: null,
-            cal_min: NaN,
-            cal_max: NaN,
-            trustCalMinMax: true,
-            percentileFrac: 0.02,
-            ignoreZeroVoxels: false,
-            useQFormNotSForm: false,
-            colormapNegative: '',
-            colormapLabel: null,
-            imageType: NVIMAGE_TYPE.NII,
-            frame4D: 0,
-            limitFrames4D: NaN,
-            // TODO the following were missing
-            url: '',
-            urlImageData: '',
+            cal_min: volume?.cal_min ?? NaN,
+            cal_max: volume?.cal_max ?? NaN,
+            trustCalMinMax: volume?.trustCalMinMax ?? true,
+            percentileFrac: volume?.percentileFrac ?? 0.02,
+            ignoreZeroVoxels: volume?.ignoreZeroVoxels ?? false,
+            useQFormNotSForm: volume?.useQFormNotSForm ?? false,
+            colormapNegative: volume?.colormapNegative ?? '',
+            colormapLabel: volume?.colormapLabel ?? null,
+            imageType: volume?.imageType ?? NVIMAGE_TYPE.NII,
+            frame4D: volume?.frame4D ?? 0,
+            limitFrames4D: volume?.limitFrames4D ?? NaN,
+            // PW: Assuming url/urlImageData should be none when embedImages is true(?)
+            url: embedImages ? '' : (volume?.url ?? ''),
+            urlImageData: embedImages ? '' : (volume?.urlImgData ?? ''),
             alphaThreshold: false,
-            cal_minNeg: NaN,
-            cal_maxNeg: NaN,
-            colorbarVisible: true
+            cal_minNeg: volume?.cal_minNeg ?? NaN,
+            cal_maxNeg: volume?.cal_maxNeg ?? NaN,
+            colorbarVisible: volume?.colorbarVisible ??true
           }
         } else {
           if (!('imageType' in imageOptions)) {
@@ -812,8 +812,8 @@ export class NVDocument {
         imageOptions.colormap = volume.colormap
         imageOptions.colormapLabel = volume.colormapLabel
         imageOptions.opacity = volume.opacity
-        imageOptions.cal_max = volume.cal_max || NaN
-        imageOptions.cal_min = volume.cal_min || NaN
+        imageOptions.cal_max = volume.cal_max ?? NaN
+        imageOptions.cal_min = volume.cal_min ?? NaN
 
         imageOptionsArray.push(imageOptions)
 
@@ -891,7 +891,7 @@ export class NVDocument {
     }
     data.meshesString = JSON.stringify(serialize(meshes))
     // Serialize drawBitmap
-    if (this.drawBitmap) {
+    if (embedDrawing && this.drawBitmap) {
       data.encodedDrawingBlob = NVUtilities.uint8tob64(this.drawBitmap)
     }
 


### PR DESCRIPTION
This PR attempts to introduce quality-of-life improvements to `NVDocument.json()`

- Introduces a new parameter, `embedDrawing` to control the population of `encodedDrawingBlob`
- If imageOptions does not exist for a particular volume, tries to set reasonable defaults from the volume itself

List of fixed issues (if they exist):

- None
