### PR TITLE
Add drawing mask slice interpolation

### DIFF
--- a/packages/niivue/demos/features/draw.ui.html
+++ b/packages/niivue/demos/features/draw.ui.html
@@ -201,6 +201,12 @@
           <a class="viewBtn dropdown-item-checked" id="ThinPen">Thin Pen</a>
           <a class="viewBtn" id="Growcut">Grow Cut</a>
           <a class="viewBtn" id="DrawOtsu">Otsu</a>
+          <a class="viewBtn divider" id="InterpolateMaskGeometricAxial">Interpolate Mask (Simple) Axial</a>
+          <a class="viewBtn" id="InterpolateMaskGeometricCoronal">Interpolate Mask (Simple) Coronal</a>
+          <a class="viewBtn" id="InterpolateMaskGeometricSagittal">Interpolate Mask (Simple) Sagittal</a>
+          <a class="viewBtn divider" id="InterpolateMaskIntensityAxial">Interpolate Mask (Intensity-Guided) Axial</a>
+          <a class="viewBtn" id="InterpolateMaskIntensityCoronal">Interpolate Mask (Intensity-Guided) Coronal</a>
+          <a class="viewBtn" id="InterpolateMaskIntensitySagittal">Interpolate Mask (Intensity-Guided) Sagittal</a>
         </div>
       </div>
       <div class="dropdown">
@@ -383,6 +389,78 @@
     if (button) button.classList.add('dropdown-item-checked')
   } // toggleGroup()
 
+  function performMaskInterpolation(useIntensityGuided, sliceType) {
+    if (!nv1.drawBitmap) {
+      return { success: false, message: 'No drawing mask available. Please create a drawing first.' }
+    }
+
+    if (!nv1.back || !nv1.back.dims) {
+      return { success: false, message: 'No background image loaded.' }
+    }
+
+    // Use drawPenAxCorSag to determine the last drawing plane
+    // let sliceType = sliceType
+    let axis
+    
+    // If drawPenAxCorSag is not set or invalid, try to use current slice type
+    if (sliceType < 0 || sliceType === undefined) {
+      if (nv1.opts.sliceType === nv1.sliceTypeRender) {
+        return { success: false, message: 'Mask interpolation does not work in render mode.' }
+      } else if (nv1.opts.sliceType === nv1.sliceTypeMultiplanar) {
+        // In multiplanar mode without a known drawing plane
+        return { success: false, message: 'Please draw on a specific pane first to determine interpolation axis.' }
+      }
+      // Single slice mode - use the current slice type
+      sliceType = nv1.opts.sliceType
+    }
+    
+    // Determine axis based on slice type
+    if (sliceType === niivue.SLICE_TYPE.AXIAL) {
+      axis = 'axial'
+    } else if (sliceType === niivue.SLICE_TYPE.CORONAL) {
+      axis = 'coronal'
+    } else if (sliceType === niivue.SLICE_TYPE.SAGITTAL) {
+      axis = 'sagittal'
+    } else {
+      return { success: false, message: 'Invalid slice type for interpolation.' }
+    }
+
+    // Find first and last slices with drawing data using the new Niivue method
+    const boundarySlices = nv1.findDrawingBoundarySlices(sliceType)
+    
+    if (!boundarySlices) {
+      return { success: false, message: 'No drawing data found in any slices.' }
+    }
+
+    if (boundarySlices.first === boundarySlices.last) {
+      return { success: false, message: 'Drawing data found in only one slice. Need at least two slices with data for interpolation.' }
+    }
+
+    const firstSliceWithData = boundarySlices.first
+    const lastSliceWithData = boundarySlices.last
+
+    // Perform interpolation using the existing method
+    try {
+      nv1.interpolateBetweenMaskSlices(firstSliceWithData, lastSliceWithData, {
+        useIntensityGuided: useIntensityGuided,
+        intensityWeight: 1.0,
+        binaryThreshold: 0.375,
+        intensitySigma: 0.1,
+        applySmoothingToSlices: true,
+        sliceType: sliceType
+      })
+      
+      return { 
+        success: true, 
+        sliceLow: firstSliceWithData, 
+        sliceHigh: lastSliceWithData,
+        axis: axis
+      }
+    } catch (error) {
+      return { success: false, message: `Error during interpolation: ${error.message}` }
+    }
+  }
+
   async function onButtonClick(event) {
     const id = event.target.id
     const buttonElement = event.target // Keep reference to the clicked element
@@ -530,6 +608,78 @@
         {
           let levels = parseInt(prompt('Segmentation classes (2..4)', '3'))
           if (!isNaN(levels)) nv1.drawOtsu(levels)
+        }
+        handled = true
+        break
+      case 'InterpolateMaskGeometricAxial':
+        {
+          const sliceType = nv1.sliceTypeAxial
+          const result = performMaskInterpolation(false, sliceType)
+          if (result.success) {
+            console.log(`Geometric interpolation completed between slices ${result.sliceLow} and ${result.sliceHigh} (${result.axis} axis)`)
+          } else {
+            alert(result.message)
+          }
+        }
+        handled = true
+        break
+      case 'InterpolateMaskGeometricCoronal':
+        {
+          const sliceType = nv1.sliceTypeCoronal
+          const result = performMaskInterpolation(false, sliceType)
+          if (result.success) {
+            console.log(`Geometric interpolation completed between slices ${result.sliceLow} and ${result.sliceHigh} (${result.axis} axis)`)
+          } else {
+            alert(result.message)
+          }
+        }
+        handled = true
+        break
+      case 'InterpolateMaskGeometricSagittal':
+        {
+          const sliceType = nv1.sliceTypeSagittal
+          const result = performMaskInterpolation(false, sliceType)
+          if (result.success) {
+            console.log(`Geometric interpolation completed between slices ${result.sliceLow} and ${result.sliceHigh} (${result.axis} axis)`)
+          } else {
+            alert(result.message)
+          }
+        }
+        handled = true
+        break
+      case 'InterpolateMaskIntensityAxial':
+        {
+          const sliceType = nv1.sliceTypeAxial
+          const result = performMaskInterpolation(true, sliceType)
+          if (result.success) {
+            console.log(`Intensity-guided interpolation completed between slices ${result.sliceLow} and ${result.sliceHigh} (${result.axis} axis)`)
+          } else {
+            alert(result.message)
+          }
+        }
+        handled = true
+        break
+      case 'InterpolateMaskIntensityCoronal':
+        {
+          const sliceType = nv1.sliceTypeCoronal
+          const result = performMaskInterpolation(true, sliceType)
+          if (result.success) {
+            console.log(`Intensity-guided interpolation completed between slices ${result.sliceLow} and ${result.sliceHigh} (${result.axis} axis)`)
+          } else {
+            alert(result.message)
+          }
+        }
+        handled = true
+        break
+      case 'InterpolateMaskIntensitySagittal':
+        {
+          const sliceType = nv1.sliceTypeSagittal
+          const result = performMaskInterpolation(true, sliceType)
+          if (result.success) {
+            console.log(`Intensity-guided interpolation completed between slices ${result.sliceLow} and ${result.sliceHigh} (${result.axis} axis)`)
+          } else {
+            alert(result.message)
+          }
         }
         handled = true
         break

--- a/packages/niivue/src/niivue/index.ts
+++ b/packages/niivue/src/niivue/index.ts
@@ -15012,4 +15012,427 @@ export class Niivue {
   set gl(gl: WebGL2RenderingContext | null) {
     this._gl = gl
   }
+
+  /**
+   * Find the first and last slices containing drawing data along a given axis
+   * @param sliceType - The slice orientation (AXIAL, CORONAL, or SAGITTAL)
+   * @returns Object containing first and last slice indices, or null if no data found
+   */
+  findDrawingBoundarySlices(sliceType: SLICE_TYPE): { first: number; last: number } | null {
+    if (!this.back || !this.back.dims || !this.drawBitmap) {
+      return null
+    }
+
+    const dims = this.back.dims
+    const [dimX, dimY, dimZ] = [dims[1], dims[2], dims[3]]
+
+    let axisSize: number
+    if (sliceType === SLICE_TYPE.AXIAL) {
+      axisSize = dimZ
+    } else if (sliceType === SLICE_TYPE.CORONAL) {
+      axisSize = dimY
+    } else if (sliceType === SLICE_TYPE.SAGITTAL) {
+      axisSize = dimX
+    } else {
+      return null
+    }
+
+    let firstSliceWithData = -1
+    let lastSliceWithData = -1
+
+    for (let slice = 0; slice < axisSize; slice++) {
+      let hasData = false
+
+      if (sliceType === SLICE_TYPE.AXIAL) {
+        // Check axial slice (XY plane at Z=slice)
+        const offset = slice * dimX * dimY
+        for (let i = 0; i < dimX * dimY; i++) {
+          if (this.drawBitmap[offset + i] > 0) {
+            hasData = true
+            break
+          }
+        }
+      } else if (sliceType === SLICE_TYPE.CORONAL) {
+        // Check coronal slice (XZ plane at Y=slice)
+        for (let z = 0; z < dimZ; z++) {
+          for (let x = 0; x < dimX; x++) {
+            const idx = x + slice * dimX + z * dimX * dimY
+            if (this.drawBitmap[idx] > 0) {
+              hasData = true
+              break
+            }
+          }
+          if (hasData) {
+            break
+          }
+        }
+      } else if (sliceType === SLICE_TYPE.SAGITTAL) {
+        // Check sagittal slice (YZ plane at X=slice)
+        for (let z = 0; z < dimZ; z++) {
+          for (let y = 0; y < dimY; y++) {
+            const idx = slice + y * dimX + z * dimX * dimY
+            if (this.drawBitmap[idx] > 0) {
+              hasData = true
+              break
+            }
+          }
+          if (hasData) {
+            break
+          }
+        }
+      }
+
+      if (hasData) {
+        if (firstSliceWithData === -1) {
+          firstSliceWithData = slice
+        }
+        lastSliceWithData = slice
+      }
+    }
+
+    if (firstSliceWithData === -1 || lastSliceWithData === -1) {
+      return null
+    }
+
+    return { first: firstSliceWithData, last: lastSliceWithData }
+  }
+
+  /**
+   * Interpolate between mask slices using geometric or intensity-guided methods
+   * @param sliceIndexLow - Lower slice index
+   * @param sliceIndexHigh - Higher slice index
+   * @param options - Interpolation options
+   */
+  interpolateBetweenMaskSlices(
+    sliceIndexLow: number,
+    sliceIndexHigh: number,
+    options: {
+      intensityWeight?: number
+      binaryThreshold?: number
+      intensitySigma?: number
+      applySmoothingToSlices?: boolean
+      useIntensityGuided?: boolean
+      sliceType?: SLICE_TYPE
+    } = {}
+  ): void {
+    if (!this.back || !this.back.dims || !this.drawBitmap) {
+      throw new Error('Background image and drawing bitmap must be loaded')
+    }
+
+    if (sliceIndexLow >= sliceIndexHigh) {
+      throw new Error('Low slice index must be less than high slice index')
+    }
+
+    const dims = this.back.dims
+    const [dimX, dimY, dimZ] = [dims[1], dims[2], dims[3]]
+
+    // Determine slice type (default to axial)
+    const sliceType = options.sliceType ?? SLICE_TYPE.AXIAL
+    // Get dimensions based on slice type
+    let sliceWidth: number, sliceHeight: number, maxSliceIndex: number
+    if (sliceType === SLICE_TYPE.AXIAL) {
+      sliceWidth = dimX
+      sliceHeight = dimY
+      maxSliceIndex = dimZ - 1
+    } else if (sliceType === SLICE_TYPE.CORONAL) {
+      sliceWidth = dimX
+      sliceHeight = dimZ
+      maxSliceIndex = dimY - 1
+    } else if (sliceType === SLICE_TYPE.SAGITTAL) {
+      sliceWidth = dimY
+      sliceHeight = dimZ
+      maxSliceIndex = dimX - 1
+    } else {
+      throw new Error('Invalid slice type. Must be AXIAL, CORONAL, or SAGITTAL')
+    }
+
+    if (sliceIndexLow < 0 || sliceIndexHigh > maxSliceIndex) {
+      throw new Error(`Slice indices out of bounds [0, ${maxSliceIndex}]`)
+    }
+
+    // Set default options
+    const opts = {
+      intensityWeight: options.intensityWeight ?? 0.7,
+      binaryThreshold: options.binaryThreshold ?? 0.375,
+      intensitySigma: options.intensitySigma ?? 0.1,
+      applySmoothingToSlices: options.applySmoothingToSlices ?? true,
+      useIntensityGuided: options.useIntensityGuided ?? true
+    }
+
+    // Extract boundary slices
+    const sliceLow = this.extractSlice(sliceIndexLow, sliceType)
+    const sliceHigh = this.extractSlice(sliceIndexHigh, sliceType)
+
+    // Skip interpolation if either boundary slice is empty
+    if (!this.hasSliceVariability(sliceLow) || !this.hasSliceVariability(sliceHigh)) {
+      return
+    }
+
+    // Apply smoothing if enabled
+    if (opts.applySmoothingToSlices) {
+      this.smoothSlice(sliceLow, sliceWidth, sliceHeight)
+      this.smoothSlice(sliceHigh, sliceWidth, sliceHeight)
+    }
+
+    // Interpolate between boundary slices
+    for (let z = sliceIndexLow + 1; z < sliceIndexHigh; z++) {
+      const interpolatedSlice = new Float32Array(sliceWidth * sliceHeight)
+
+      if (opts.useIntensityGuided && this.back.img) {
+        // Intensity-guided interpolation
+        this.performIntensityGuidedInterpolation(
+          sliceLow,
+          sliceHigh,
+          z,
+          sliceIndexLow,
+          sliceIndexHigh,
+          interpolatedSlice,
+          opts,
+          sliceType
+        )
+      } else {
+        // Geometric interpolation
+        this.performGeometricInterpolation(sliceLow, sliceHigh, z, sliceIndexLow, sliceIndexHigh, interpolatedSlice)
+      }
+
+      // Insert interpolated slice back into drawing bitmap
+      this.insertSlice(interpolatedSlice, z, sliceType, opts.binaryThreshold)
+    }
+
+    // Update the drawing texture
+    this.refreshDrawing(true)
+  }
+
+  private extractSlice(sliceIndex: number, sliceType: SLICE_TYPE): Float32Array {
+    if (!this.back || !this.back.dims || !this.drawBitmap) {
+      throw new Error('Background image and drawing bitmap required')
+    }
+
+    const dims = this.back.dims
+    const [dimX, dimY, dimZ] = [dims[1], dims[2], dims[3]]
+
+    let sliceData: Float32Array
+    if (sliceType === SLICE_TYPE.AXIAL) {
+      // Extract axial slice (XY plane at Z=sliceIndex)
+      sliceData = new Float32Array(dimX * dimY)
+      const offset = sliceIndex * dimX * dimY
+      for (let i = 0; i < dimX * dimY; i++) {
+        sliceData[i] = this.drawBitmap[offset + i]
+      }
+    } else if (sliceType === SLICE_TYPE.CORONAL) {
+      // Extract coronal slice (XZ plane at Y=sliceIndex)
+      sliceData = new Float32Array(dimX * dimZ)
+      for (let z = 0; z < dimZ; z++) {
+        for (let x = 0; x < dimX; x++) {
+          const srcIdx = x + sliceIndex * dimX + z * dimX * dimY
+          const dstIdx = x + z * dimX
+          sliceData[dstIdx] = this.drawBitmap[srcIdx]
+        }
+      }
+    } else if (sliceType === SLICE_TYPE.SAGITTAL) {
+      // Extract sagittal slice (YZ plane at X=sliceIndex)
+      sliceData = new Float32Array(dimY * dimZ)
+      for (let z = 0; z < dimZ; z++) {
+        for (let y = 0; y < dimY; y++) {
+          const srcIdx = sliceIndex + y * dimX + z * dimX * dimY
+          const dstIdx = y + z * dimY
+          sliceData[dstIdx] = this.drawBitmap[srcIdx]
+        }
+      }
+    } else {
+      throw new Error('Invalid slice type')
+    }
+
+    return sliceData
+  }
+
+  private extractIntensitySlice(sliceIndex: number, sliceType: SLICE_TYPE): Float32Array {
+    if (!this.back || !this.back.dims || !this.back.img) {
+      throw new Error('Background image required for intensity data')
+    }
+
+    const dims = this.back.dims
+    const [dimX, dimY, dimZ] = [dims[1], dims[2], dims[3]]
+    const maxVal = this.back.global_max
+
+    let sliceData: Float32Array
+    if (sliceType === SLICE_TYPE.AXIAL) {
+      // Extract axial slice (XY plane at Z=sliceIndex)
+      sliceData = new Float32Array(dimX * dimY)
+      const offset = sliceIndex * dimX * dimY
+      for (let i = 0; i < dimX * dimY; i++) {
+        sliceData[i] = this.back.img[offset + i] / maxVal
+      }
+    } else if (sliceType === SLICE_TYPE.CORONAL) {
+      // Extract coronal slice (XZ plane at Y=sliceIndex)
+      sliceData = new Float32Array(dimX * dimZ)
+      for (let z = 0; z < dimZ; z++) {
+        for (let x = 0; x < dimX; x++) {
+          const srcIdx = x + sliceIndex * dimX + z * dimX * dimY
+          const dstIdx = x + z * dimX
+          sliceData[dstIdx] = this.back.img[srcIdx] / maxVal
+        }
+      }
+    } else if (sliceType === SLICE_TYPE.SAGITTAL) {
+      // Extract sagittal slice (YZ plane at X=sliceIndex)
+      sliceData = new Float32Array(dimY * dimZ)
+      for (let z = 0; z < dimZ; z++) {
+        for (let y = 0; y < dimY; y++) {
+          const srcIdx = sliceIndex + y * dimX + z * dimX * dimY
+          const dstIdx = y + z * dimY
+          sliceData[dstIdx] = this.back.img[srcIdx] / maxVal
+        }
+      }
+    } else {
+      throw new Error('Invalid slice type')
+    }
+
+    return sliceData
+  }
+
+  private insertSlice(slice: Float32Array, sliceIndex: number, sliceType: SLICE_TYPE, binaryThreshold: number): void {
+    if (!this.drawBitmap || !this.back || !this.back.dims) {
+      throw new Error('Drawing bitmap and background required')
+    }
+
+    const dims = this.back.dims
+    const [dimX, dimY, dimZ] = [dims[1], dims[2], dims[3]]
+
+    if (sliceType === SLICE_TYPE.AXIAL) {
+      // Insert axial slice (XY plane at Z=sliceIndex)
+      const offset = sliceIndex * dimX * dimY
+      for (let i = 0; i < slice.length; i++) {
+        this.drawBitmap[offset + i] = slice[i] >= binaryThreshold ? this.opts.penValue : 0
+      }
+    } else if (sliceType === SLICE_TYPE.CORONAL) {
+      // Insert coronal slice (XZ plane at Y=sliceIndex)
+      for (let z = 0; z < dimZ; z++) {
+        for (let x = 0; x < dimX; x++) {
+          const srcIdx = x + z * dimX
+          const dstIdx = x + sliceIndex * dimX + z * dimX * dimY
+          this.drawBitmap[dstIdx] = slice[srcIdx] >= binaryThreshold ? this.opts.penValue : 0
+        }
+      }
+    } else if (sliceType === SLICE_TYPE.SAGITTAL) {
+      // Insert sagittal slice (YZ plane at X=sliceIndex)
+      for (let z = 0; z < dimZ; z++) {
+        for (let y = 0; y < dimY; y++) {
+          const srcIdx = y + z * dimY
+          const dstIdx = sliceIndex + y * dimX + z * dimX * dimY
+          this.drawBitmap[dstIdx] = slice[srcIdx] >= binaryThreshold ? this.opts.penValue : 0
+        }
+      }
+    } else {
+      throw new Error('Invalid slice type')
+    }
+  }
+
+  private smoothSlice(slice: Float32Array, width: number, height: number): void {
+    if (width < 3 || height < 3) {
+      return
+    }
+
+    const temp = new Float32Array(slice.length)
+
+    // Smooth in X direction
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const idx = x + y * width
+        if (x === 0 || x === width - 1) {
+          temp[idx] = slice[idx]
+        } else {
+          temp[idx] = (slice[idx - 1] + 2 * slice[idx] + slice[idx + 1]) * 0.25
+        }
+      }
+    }
+
+    // Smooth in Y direction
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const idx = x + y * width
+        if (y === 0 || y === height - 1) {
+          slice[idx] = temp[idx]
+        } else {
+          slice[idx] = (temp[idx - width] + 2 * temp[idx] + temp[idx + width]) * 0.25
+        }
+      }
+    }
+  }
+
+  private hasSliceVariability(slice: Float32Array): boolean {
+    return slice.some((value) => value > 0)
+  }
+
+  private calculateIntensityWeight(
+    intensity1: number,
+    intensity2: number,
+    targetIntensity: number,
+    intensitySigma: number
+  ): number {
+    const diff1 = Math.abs(targetIntensity - intensity1)
+    const diff2 = Math.abs(targetIntensity - intensity2)
+
+    const weight1 = Math.exp((-diff1 * diff1) / (2 * intensitySigma * intensitySigma))
+    const weight2 = Math.exp((-diff2 * diff2) / (2 * intensitySigma * intensitySigma))
+
+    const totalWeight = weight1 + weight2
+    if (totalWeight < 1e-6) {
+      return 0.5
+    }
+
+    return weight1 / totalWeight
+  }
+
+  private performGeometricInterpolation(
+    sliceLow: Float32Array,
+    sliceHigh: Float32Array,
+    z: number,
+    sliceIndexLow: number,
+    sliceIndexHigh: number,
+    interpolatedSlice: Float32Array
+  ): void {
+    const fracHigh = (z - sliceIndexLow) / (sliceIndexHigh - sliceIndexLow)
+    const fracLow = 1 - fracHigh
+
+    for (let i = 0; i < sliceLow.length; i++) {
+      interpolatedSlice[i] = sliceLow[i] * fracLow + sliceHigh[i] * fracHigh
+    }
+  }
+
+  private performIntensityGuidedInterpolation(
+    sliceLow: Float32Array,
+    sliceHigh: Float32Array,
+    z: number,
+    sliceIndexLow: number,
+    sliceIndexHigh: number,
+    interpolatedSlice: Float32Array,
+    opts: { intensityWeight: number; intensitySigma: number },
+    sliceType: SLICE_TYPE
+  ): void {
+    const intensityLow = this.extractIntensitySlice(sliceIndexLow, sliceType)
+    const intensityHigh = this.extractIntensitySlice(sliceIndexHigh, sliceType)
+    const targetIntensity = this.extractIntensitySlice(z, sliceType)
+
+    const baseFracHigh = (z - sliceIndexLow) / (sliceIndexHigh - sliceIndexLow)
+    const baseFracLow = 1 - baseFracHigh
+
+    for (let i = 0; i < sliceLow.length; i++) {
+      if (sliceLow[i] > 0 || sliceHigh[i] > 0) {
+        const intensityWeight = this.calculateIntensityWeight(
+          intensityLow[i],
+          intensityHigh[i],
+          targetIntensity[i],
+          opts.intensitySigma
+        )
+
+        const alpha = opts.intensityWeight
+        const combinedWeightLow = alpha * intensityWeight + (1 - alpha) * baseFracLow
+        const combinedWeightHigh = 1 - combinedWeightLow
+
+        interpolatedSlice[i] = sliceLow[i] * combinedWeightLow + sliceHigh[i] * combinedWeightHigh
+      } else {
+        interpolatedSlice[i] = sliceLow[i] * baseFracLow + sliceHigh[i] * baseFracHigh
+      }
+    }
+  }
 }


### PR DESCRIPTION
This PR implements drawing mask slice interpolation using two methods. The first method mimics the slice interpolation used in [MRIcroGL](https://github.com/rordenlab/MRIcroGL/blob/ebe3a307fa4bd6343ef91f11784195463941fba9/drawvolume.pas#L1353). Only the mask is used to fill in missing slices.

The second method uses the the background image (`nv.back`) voxel intensities to influence how the missing mask slices are filled in. For example, if you draw a mask that covers something very bright, then it's likely dark tissue is less interesting to you. In this case, these dark tissue voxels will have less influence on filled in mask voxels. The same logic applies to the reverse scenario (you create a mask on top of dark voxels and are less interested in bright voxels). 

List of fixed issues (if they exist):

- closes #1378 
