### PR TITLE
Fix: Crosshairs drag state not resetting on mouse leave

### DIFF
--- a/packages/niivue/src/niivue/index.ts
+++ b/packages/niivue/src/niivue/index.ts
@@ -2164,7 +2164,7 @@ export class Niivue {
     }
 
     // Reset drag state if mouse leaves during drag
-    if (this.uiData.isDragging) {
+    if (this.uiData.isDragging || this.uiData.mousedown) {
       log.debug('Mouse left canvas during drag, resetting drag state.')
       this.uiData.isDragging = false
       this.uiData.mouseButtonLeftDown = false
@@ -2215,7 +2215,6 @@ export class Niivue {
       }
       // Handle all other drag modes that need drag tracking
       this.setDragEnd(pos.x, pos.y)
-
       this.drawScene()
       this.uiData.prevX = this.uiData.currX
       this.uiData.prevY = this.uiData.currY


### PR DESCRIPTION
This PR fixes an issue where the DnD event doesn't end when the mouse cursor leaves the canvas element. It also removes some unnecessary usages of `else`.

How to reproduce the issue:
1. Press the mouse button on the canvas.
2. Drag the cursor out of the canvas.
3. Release the mouse button, then move the cursor back onto the canvas.
-> You'll see the DnD event doesn't end.


https://github.com/user-attachments/assets/30d4a244-dfce-4a58-8695-0dc1be085587

