### PR TITLE
Add LAMBADA (OpenBrainAtlas) to Projects using NiiVue

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ npm run dev
 - [Slice:Drop Reloaded](https://gaiborjosue.github.io/slicedrop.github.com/reload/) uses NiiVue to extend the original [slicedrop](https://slicedrop.com/)
 - [VoxLogicA-UI](https://voxlogica-project.github.io/VoxLogicA-UI/) makes advanced medical
 imaging analysis intuitive
-- [Lambada (OpenBrainAtlas)](https://lambada.icm-institute.org/) – A reference atlas of the developing postnatal mouse brain, created using tissue clearing and light-sheet microscopy at the Paris Brain Institute (Institut du Cerveau). It uses NiiVue for 2D/3D visualization of brain structures, volume overlays, and mesh rendering.
+- [LAMBADA (OpenBrainAtlas)](https://lambada.icm-institute.org/) – A reference atlas of the developing postnatal mouse brain, created using tissue clearing and light-sheet microscopy at the Paris Brain Institute (Institut du Cerveau). It uses NiiVue for 2D/3D visualization of brain structures, volume overlays, and mesh rendering.
 
 # Funding
 


### PR DESCRIPTION
This PR adds [LAMBADA (OpenBrainAtlas)](https://lambada.icm-institute.org/) to the "Projects using NiiVue" section in the README.

LAMBADA is a reference atlas of the developing postnatal mouse brain, created using tissue clearing and light-sheet microscopy at the Paris Brain Institute (Institut du Cerveau). It uses NiiVue for 2D/3D visualization of brain structures, volume overlays, and mesh rendering.