### PR TITLE
Detect MGH label from version signature

### DIFF
--- a/packages/niivue/src/nvimage/ImageReaders/mgh.ts
+++ b/packages/niivue/src/nvimage/ImageReaders/mgh.ts
@@ -180,9 +180,10 @@ export function isFreeSurferLabelImage(raw: ArrayBuffer, hdr: NIFTI1 | NIFTI2, e
  * and returning the raw image data buffer.
  * @param nvImage - The NVImage instance whose header will be modified.
  * @param buffer - ArrayBuffer containing the MGH/MGZ file data.
+ * @param name - optional name of image, allowing label detection.
  * @returns Promise resolving to the imgRaw ArrayBuffer or null on critical error.
  */
-export async function readMgh(nvImage: NVImage, buffer: ArrayBuffer): Promise<ArrayBuffer | null> {
+export async function readMgh(nvImage: NVImage, buffer: ArrayBuffer, name: string = ''): Promise<ArrayBuffer | null> {
     if (!nvImage.hdr) {
         log.debug('readMgh called before nvImage.hdr was initialized. Creating default.')
         nvImage.hdr = new NIFTI1() // Ensure header object exists
@@ -234,9 +235,6 @@ export async function readMgh(nvImage: NVImage, buffer: ArrayBuffer): Promise<Ar
 
     if (version !== 1 && version !== 257) {
         log.warn(`Unexpected MGH version: ${version}.`)
-    }
-    if (version === 257) {
-        hdr.intent_code = 1002
     }
     if (width <= 0 || height <= 0 || depth <= 0) {
         log.error(`Invalid MGH dimensions: ${width}x${height}x${depth}`)
@@ -326,7 +324,70 @@ export async function readMgh(nvImage: NVImage, buffer: ArrayBuffer): Promise<Ar
     const expectedBytes = nVoxels * nBytesPerVoxel
     // Return only the raw image data buffer
     const imgRaw = raw.slice(hdr.vox_offset, hdr.vox_offset + expectedBytes)
-    if (version === 257 || isFreeSurferLabelImage(raw, hdr, expectedBytes)) {
+    // label detection based on:
+    // https://github.com/pwighton/mgz-optimize/blob/main/mgz_optimize.py
+    // option 1: detect label by version number
+    let isLabel = version === 257
+    // option 2: detect label by filename
+    if (!isLabel) {
+        const mgLabelFiles = [
+            'aparc.DKTatlas+aseg.deep.mg',
+            'aparc+aseg.mg',
+            'aparc.DKTatlas+aseg.mg',
+            'aparc.a2005s+aseg.mg',
+            'aparc.a2009s+aseg.mg',
+            'apas+head.mg',
+            'apas+head.samseg.mg',
+            'aseg.auto.mg',
+            'aseg.auto_noCCseg.mg',
+            'aseg.mg',
+            'aseg.presurf.hypos.mg',
+            'aseg.presurf.mg',
+            'brainstemSsLabels.v13.FSvoxelSpace.mg',
+            'brainstemSsLabels.v13.mg',
+            'ctrl_pts.mg',
+            'filled.auto.mg',
+            'filled.mg',
+            'gtmseg.mg',
+            'hypothalamic_subunits_seg.v1.mg',
+            'lh.hippoAmygLabels-T1.v22.CA.FSvoxelSpace.mg',
+            'lh.hippoAmygLabels-T1.v22.CA.mg',
+            'lh.hippoAmygLabels-T1.v22.FS60.FSvoxelSpace.mg',
+            'lh.hippoAmygLabels-T1.v22.FS60.mg',
+            'lh.hippoAmygLabels-T1.v22.FSvoxelSpace.mg',
+            'lh.hippoAmygLabels-T1.v22.HBT.FSvoxelSpace.mg',
+            'lh.hippoAmygLabels-T1.v22.HBT.mg',
+            'lh.hippoAmygLabels-T1.v22.mg',
+            'lh.ribbon.mg',
+            'mca-dura.mg',
+            'rh.hippoAmygLabels-T1.v22.CA.FSvoxelSpace.mg',
+            'rh.hippoAmygLabels-T1.v22.CA.mg',
+            'rh.hippoAmygLabels-T1.v22.FS60.FSvoxelSpace.mg',
+            'rh.hippoAmygLabels-T1.v22.FS60.mg',
+            'rh.hippoAmygLabels-T1.v22.FSvoxelSpace.mg',
+            'rh.hippoAmygLabels-T1.v22.HBT.FSvoxelSpace.mg',
+            'rh.hippoAmygLabels-T1.v22.HBT.mg',
+            'rh.hippoAmygLabels-T1.v22.mg',
+            'rh.ribbon.mg',
+            'ribbon.mg',
+            'synthseg.mg',
+            'synthseg.rca.mg',
+            'vsinus.mg',
+            'subcort.mask.1mm.mg',
+            'subcort.mask.mg',
+            'surface.defects.mg',
+            'ThalamicNuclei.v13.T1.FSvoxelSpace.mg',
+            'ThalamicNuclei.v13.T1.mg',
+            'wm.asegedit.mg',
+            'wmparc.mg'
+        ]
+        isLabel = mgLabelFiles.some((label) => name.includes(label))
+    }
+    // option 3: detect label using MGH footer
+    if (!isLabel) {
+        isLabel = isFreeSurferLabelImage(raw, hdr, expectedBytes)
+    }
+    if (isLabel) {
         return optimizeFreeSurferLabels(hdr, imgRaw)
     }
     return imgRaw

--- a/packages/niivue/src/nvimage/index.ts
+++ b/packages/niivue/src/nvimage/index.ts
@@ -344,7 +344,7 @@ export class NVImage {
                 break
             case NVIMAGE_TYPE.MGH:
             case NVIMAGE_TYPE.MGZ:
-                imgRaw = await ImageReaders.Mgh.readMgh(newImg, dataBuffer as ArrayBuffer)
+                imgRaw = await ImageReaders.Mgh.readMgh(newImg, dataBuffer as ArrayBuffer, name)
                 if (imgRaw === null) {
                     throw new Error(`Failed to parse MGH/MGZ file ${name}`)
                 }


### PR DESCRIPTION
List of fixed issues (if they exist):

- #1498

This tiny patch works with @pwighton's [mgz-optimize](https://github.com/pwighton/mgz-optimize). That Python code will distinguish indexed labels from scalar images by setting the initial signature bytes (the [version](https://surfer.nmr.mgh.harvard.edu/fswiki/FsTutorial/MghFormat)) to 257 instead of 1. This will allow NiiVue to autodetect MGH label maps (assuming the image uses the [MGZ_INTENT_LABEL](https://github.com/freesurfer/freesurfer/blob/ff8dccb14c0b8fa5e514ce22717df82fd1098100/include/mri.h#L630) flag).

It also adopts the [mgz-optimize](https://github.com/pwighton/mgz-optimize) method for detecting labels based on filenames.
