### PR TITLE
docs: fix typo 'also also' in develop.mdx

### DIFF
--- a/packages/docs/docs/develop.mdx
+++ b/packages/docs/docs/develop.mdx
@@ -39,7 +39,7 @@ npm run build:niivue
 npm run dev:docs
 ```
 
-Note the embedded [JSDoc](https://jsdoc.app/) annotations that describe the API and include links to live demos are also also compiled by `build:niivue` into [web pages](./api/niivue/classes/Niivue#methods).
+Note the embedded [JSDoc](https://jsdoc.app/) annotations that describe the API and include links to live demos are also compiled by `build:niivue` into [web pages](./api/niivue/classes/Niivue#methods).
 
 ## Alternatives
 


### PR DESCRIPTION
Fixed a small typo in `packages/docs/docs/develop.mdx` where the word "also" was repeated (also also).
Change: removed duplicate "also" under the "Documentation Development" section.

