### PR TITLE
feat: add setRenderView API for anatomical snapping

### DIFF
--- a/packages/niivue/src/niivue/index.ts
+++ b/packages/niivue/src/niivue/index.ts
@@ -3646,7 +3646,7 @@ export class Niivue {
         this.drawScene()
     }
 
-   /**
+    /**
      * Snap the 3D render camera to a specific anatomical view.
      * @param view - The target view. Supported values (case-insensitive): 'Top'/'Superior', 'Bottom'/'Inferior', 'Left', 'Right', 'Front'/'Anterior', 'Back'/'Posterior'.
      * @see {@link https://github.com/niivue/niivue/issues/1464 | Issue 1464}
@@ -3658,20 +3658,26 @@ export class Niivue {
 
         // Standard anatomical views (Azimuth, Elevation)
         if (v === 'top' || v === 'superior') {
-            a = 0; e = 90;
+            a = 0
+            e = 90
         } else if (v === 'bottom' || v === 'inferior') {
-            a = 0; e = -90;
+            a = 0
+            e = -90
         } else if (v === 'left') {
-            a = 90; e = 0;
+            a = 90
+            e = 0
         } else if (v === 'right') {
-            a = -90; e = 0;
+            a = -90
+            e = 0
         } else if (v === 'front' || v === 'anterior') {
-            a = 180; e = 0;
+            a = 180
+            e = 0
         } else if (v === 'back' || v === 'posterior') {
-            a = 0; e = 0;
+            a = 0
+            e = 0
         } else {
-            console.warn('Unknown view:', view);
-            return;
+            console.warn('Unknown view:', view)
+            return
         }
 
         this.setRenderAzimuthElevation(a, e)

--- a/packages/niivue/tests/unit/niivue.test.ts
+++ b/packages/niivue/tests/unit/niivue.test.ts
@@ -1,156 +1,155 @@
 import { expect, test, vi, beforeAll } from 'vitest'
-import { Niivue, PEN_TYPE, SLICE_TYPE } from '../../src/niivue/index.js' // note the js extension
 import { vec4 } from 'gl-matrix'
+import { Niivue, PEN_TYPE, SLICE_TYPE } from '../../src/niivue/index.js' // note the js extension
 
 // Mock WebGL-dependent methods
 beforeAll(() => {
-  vi.spyOn(Niivue.prototype, 'drawScene').mockImplementation(() => {})
-  vi.spyOn(Niivue.prototype, 'updateGLVolume').mockImplementation(() => {})
+    vi.spyOn(Niivue.prototype, 'drawScene').mockImplementation(() => {})
+    vi.spyOn(Niivue.prototype, 'updateGLVolume').mockImplementation(() => {})
 })
 
 test('backColor defaults to black', () => {
-  const nv = new Niivue()
-  expect(nv.opts.backColor).toStrictEqual([0, 0, 0, 1])
+    const nv = new Niivue()
+    expect(nv.opts.backColor).toStrictEqual([0, 0, 0, 1])
 })
 
 test('crosshairColor can be set', async () => {
-  const nv = new Niivue()
-  const green = [0, 1, 0, 1] // RGBA green
-  await nv.setCrosshairColor(green)
-  expect(nv.opts.crosshairColor).toStrictEqual(green)
+    const nv = new Niivue()
+    const green = [0, 1, 0, 1] // RGBA green
+    await nv.setCrosshairColor(green)
+    expect(nv.opts.crosshairColor).toStrictEqual(green)
 })
 
 test('options are copied and not referenced', () => {
-  const nv1 = new Niivue()
-  const nv2 = new Niivue()
-  nv1.setSliceType(SLICE_TYPE.SAGITTAL)
-  nv2.setSliceType(SLICE_TYPE.AXIAL)
-  expect(nv1.opts.sliceType).toBe(2) // SLICE_TYPE.SAGITTAL
+    const nv1 = new Niivue()
+    const nv2 = new Niivue()
+    nv1.setSliceType(SLICE_TYPE.SAGITTAL)
+    nv2.setSliceType(SLICE_TYPE.AXIAL)
+    expect(nv1.opts.sliceType).toBe(2) // SLICE_TYPE.SAGITTAL
 })
 
 test('azimuth and elevation set by setRenderAzimuthElevation is tracked in document', () => {
-  const expectedAzimuth = 77
-  const expectedElevation = 88
+    const expectedAzimuth = 77
+    const expectedElevation = 88
 
-  const nv = new Niivue()
-  nv.setRenderAzimuthElevation(expectedAzimuth, expectedElevation)
-  expect(nv.document.scene.renderAzimuth).toBe(expectedAzimuth)
-  expect(nv.document.scene.renderElevation).toBe(expectedElevation)
+    const nv = new Niivue()
+    nv.setRenderAzimuthElevation(expectedAzimuth, expectedElevation)
+    expect(nv.document.scene.renderAzimuth).toBe(expectedAzimuth)
+    expect(nv.document.scene.renderElevation).toBe(expectedElevation)
 })
 
 test('pan2Dxyzmm set by setPan2Dxyzmm is tracked in document', () => {
-  const nv = new Niivue()
-  const pan2Dxyzmm = vec4.fromValues(5, -4, 2, 1.5)
-  nv.setPan2Dxyzmm(pan2Dxyzmm)
-  expect(nv.document.scene.pan2Dxyzmm).toBe(pan2Dxyzmm)
+    const nv = new Niivue()
+    const pan2Dxyzmm = vec4.fromValues(5, -4, 2, 1.5)
+    nv.setPan2Dxyzmm(pan2Dxyzmm)
+    expect(nv.document.scene.pan2Dxyzmm).toBe(pan2Dxyzmm)
 })
 
 test('isSliceMM set by setSliceMM is tracked in document', () => {
-  const nv = new Niivue()
-  nv.setSliceMM(false)
-  nv.setSliceMM(true)
-  expect(nv.document.opts.isSliceMM).toBe(true)
-  nv.setSliceMM(false)
-  expect(nv.document.opts.isSliceMM).toBe(false)
+    const nv = new Niivue()
+    nv.setSliceMM(false)
+    nv.setSliceMM(true)
+    expect(nv.document.opts.isSliceMM).toBe(true)
+    nv.setSliceMM(false)
+    expect(nv.document.opts.isSliceMM).toBe(false)
 })
 
 test('isAdditiveBlend set by setAdditiveBlend is tracked in document', () => {
-  const nv = new Niivue()
-  nv.setAdditiveBlend(false)
-  nv.setAdditiveBlend(true)
-  expect(nv.document.opts.isAdditiveBlend).toBe(true)
-  nv.setAdditiveBlend(false)
-  expect(nv.document.opts.isAdditiveBlend).toBe(false)
+    const nv = new Niivue()
+    nv.setAdditiveBlend(false)
+    nv.setAdditiveBlend(true)
+    expect(nv.document.opts.isAdditiveBlend).toBe(true)
+    nv.setAdditiveBlend(false)
+    expect(nv.document.opts.isAdditiveBlend).toBe(false)
 })
 
 test('sliceMosaicString set by setSliceMosaicString is tracked in document', () => {
-  const nv = new Niivue()
-  const mosaic = 'A 0 20 C 30 S 42'
-  nv.setSliceMosaicString(mosaic)
-  expect(nv.document.opts.sliceMosaicString).toBe(mosaic)
+    const nv = new Niivue()
+    const mosaic = 'A 0 20 C 30 S 42'
+    nv.setSliceMosaicString(mosaic)
+    expect(nv.document.opts.sliceMosaicString).toBe(mosaic)
 })
 
 test('meshThicknessOn2D set by setMeshThicknessOn2D is tracked in document', () => {
-  const nv = new Niivue()
-  const meshThickness = 7
-  nv.setMeshThicknessOn2D(meshThickness)
-  expect(nv.document.opts.meshThicknessOn2D).toBe(meshThickness)
+    const nv = new Niivue()
+    const meshThickness = 7
+    nv.setMeshThicknessOn2D(meshThickness)
+    expect(nv.document.opts.meshThicknessOn2D).toBe(meshThickness)
 })
 
 test('isHighResolutionCapable set by setHighResolutionCapable is tracked in document', () => {
-  const nv = new Niivue()
-  nv.setHighResolutionCapable(-1)
-  nv.setHighResolutionCapable(0)
-  expect(nv.document.opts.forceDevicePixelRatio).toBe(0)
-  nv.setHighResolutionCapable(-1)
-  expect(nv.document.opts.forceDevicePixelRatio).toBe(-1)
+    const nv = new Niivue()
+    nv.setHighResolutionCapable(-1)
+    nv.setHighResolutionCapable(0)
+    expect(nv.document.opts.forceDevicePixelRatio).toBe(0)
+    nv.setHighResolutionCapable(-1)
+    expect(nv.document.opts.forceDevicePixelRatio).toBe(-1)
 })
 
 test('isRadiologicalConvention set by setRadiologicalConvention is tracked in document', () => {
-  const nv = new Niivue()
-  nv.setRadiologicalConvention(false)
-  nv.setRadiologicalConvention(true)
-  expect(nv.document.opts.isRadiologicalConvention).toBe(true)
-  nv.setRadiologicalConvention(false)
-  expect(nv.document.opts.isRadiologicalConvention).toBe(false)
+    const nv = new Niivue()
+    nv.setRadiologicalConvention(false)
+    nv.setRadiologicalConvention(true)
+    expect(nv.document.opts.isRadiologicalConvention).toBe(true)
+    nv.setRadiologicalConvention(false)
+    expect(nv.document.opts.isRadiologicalConvention).toBe(false)
 })
 
 test('isCornerOrientationText set by setCornerOrientationText is tracked in document', () => {
-  const nv = new Niivue()
-  nv.setCornerOrientationText(false)
-  nv.setCornerOrientationText(true)
-  expect(nv.document.opts.isCornerOrientationText).toBe(true)
-  nv.setCornerOrientationText(false)
-  expect(nv.document.opts.isCornerOrientationText).toBe(false)
+    const nv = new Niivue()
+    nv.setCornerOrientationText(false)
+    nv.setCornerOrientationText(true)
+    expect(nv.document.opts.isCornerOrientationText).toBe(true)
+    nv.setCornerOrientationText(false)
+    expect(nv.document.opts.isCornerOrientationText).toBe(false)
 })
 
 test('multiplanarLayout set by setMultiplanarLayout is tracked in document', () => {
-  const nv = new Niivue()
-  const multiplanarLayout = 3
-  nv.setMultiplanarLayout(multiplanarLayout)
-  expect(nv.document.opts.multiplanarLayout).toBe(multiplanarLayout)
+    const nv = new Niivue()
+    const multiplanarLayout = 3
+    nv.setMultiplanarLayout(multiplanarLayout)
+    expect(nv.document.opts.multiplanarLayout).toBe(multiplanarLayout)
 })
 
 test('multiplanarPadPixels set by setMultiplanarPadPixels is tracked in document', () => {
-  const nv = new Niivue()
-  const multiplanarPadPixels = 4
-  nv.setMultiplanarPadPixels(multiplanarPadPixels)
-  expect(nv.document.opts.multiplanarPadPixels).toBe(multiplanarPadPixels)
+    const nv = new Niivue()
+    const multiplanarPadPixels = 4
+    nv.setMultiplanarPadPixels(multiplanarPadPixels)
+    expect(nv.document.opts.multiplanarPadPixels).toBe(multiplanarPadPixels)
 })
 
-
 test('showAllOrientationMarkers set by setShowAllOrientationMarkers is tracked in document', () => {
-  const nv = new Niivue()
-  // Default should be false
-  expect(nv.document.opts.showAllOrientationMarkers).toBe(false)
-  
-  nv.setShowAllOrientationMarkers(true)
-  expect(nv.document.opts.showAllOrientationMarkers).toBe(true)
-  
-  nv.setShowAllOrientationMarkers(false)
-  expect(nv.document.opts.showAllOrientationMarkers).toBe(false)
+    const nv = new Niivue()
+    // Default should be false
+    expect(nv.document.opts.showAllOrientationMarkers).toBe(false)
+
+    nv.setShowAllOrientationMarkers(true)
+    expect(nv.document.opts.showAllOrientationMarkers).toBe(true)
+
+    nv.setShowAllOrientationMarkers(false)
+    expect(nv.document.opts.showAllOrientationMarkers).toBe(false)
 })
 
 test('penType defaults to pen', () => {
-  const nv = new Niivue()
-  expect(nv.document.opts.penType).toBe(PEN_TYPE.PEN)
+    const nv = new Niivue()
+    expect(nv.document.opts.penType).toBe(PEN_TYPE.PEN)
 })
 
 test('penType can be set to rectangle', () => {
-  const nv = new Niivue()
-  nv.document.opts.penType = PEN_TYPE.RECTANGLE
-  expect(nv.document.opts.penType).toBe(PEN_TYPE.RECTANGLE)
+    const nv = new Niivue()
+    nv.document.opts.penType = PEN_TYPE.RECTANGLE
+    expect(nv.document.opts.penType).toBe(PEN_TYPE.RECTANGLE)
 })
 
 test('penType can be set to ellipse', () => {
-  const nv = new Niivue()
-  nv.document.opts.penType = PEN_TYPE.ELLIPSE
-  expect(nv.document.opts.penType).toBe(PEN_TYPE.ELLIPSE)
+    const nv = new Niivue()
+    nv.document.opts.penType = PEN_TYPE.ELLIPSE
+    expect(nv.document.opts.penType).toBe(PEN_TYPE.ELLIPSE)
 })
 
 test('setRenderView snaps to anatomical views', async () => {
     const niivue = new Niivue()
-    
+
     // Test Top/Superior
     niivue.setRenderView('Top')
     expect(niivue.scene.renderElevation).toBe(90)
@@ -170,4 +169,4 @@ test('setRenderView snaps to anatomical views', async () => {
     const consoleSpy = vi.spyOn(console, 'warn')
     niivue.setRenderView('NotAView')
     expect(consoleSpy).toHaveBeenCalledWith('Unknown view:', 'NotAView')
-  })
+})


### PR DESCRIPTION
### Description
This PR implements the camera logic required for **Issue #1464** ("Add snapping to specific views").

It adds a public API method `setRenderView(view: string)` to the core `Niivue` class. This method accepts standard anatomical views (`Top`, `Bottom`, `Left`, `Right`, `Anterior`, `Posterior`) and automatically calculates and sets the correct `renderAzimuth` and `renderElevation`.

### Why this helps
This backend logic is the prerequisite for adding UI menu buttons. It allows any UI layer (Context Menu, Desktop App, etc.) to simply call `nv.setRenderView('Top')` without needing to manually calculate camera angles.

### Testing
I verified this locally by running the dev server and triggering the function manually via the console.

**Screenshots of specific view snapping:**
(images below for Top, Left, Anterior, and Posterior views)

**TOP**
<img width="1919" height="1086" alt="Screenshot 2026-01-27 213458" src="https://github.com/user-attachments/assets/a0d36b9f-9111-414e-977e-c6571a1b9894" />

**LEFT**
<img width="1919" height="1101" alt="Screenshot 2026-01-27 214728" src="https://github.com/user-attachments/assets/ae2a9982-0087-4204-866e-4957e102cec9" />

**ANTERIOR**
<img width="1919" height="1100" alt="Screenshot 2026-01-27 214850" src="https://github.com/user-attachments/assets/c3a3a453-e47b-4299-9a32-bb9a9074577c" />

**POSTERIOR**
<img width="1915" height="1085" alt="Screenshot 2026-01-27 214938" src="https://github.com/user-attachments/assets/f3879279-3823-4c7a-bb90-021f067b10c8" />

