### PR TITLE
fix: trigger sync during slicer3D drag operations (closes #1400)

### DIFF
--- a/packages/niivue/src/niivue/index.ts
+++ b/packages/niivue/src/niivue/index.ts
@@ -1849,6 +1849,9 @@ export class Niivue {
             }
             // Handle all other drag modes that need drag tracking
             this.setDragEnd(pos.x, pos.y)
+            if (activeDragMode === DRAG_MODE.slicer3D) {
+                this.sync()
+            }
             this.drawScene()
             this.uiData.prevX = this.uiData.currX
             this.uiData.prevY = this.uiData.currY


### PR DESCRIPTION
Fixes #1400

Added `this.sync()` call when dragging in slicer3D mode so that synced canvases update during drag operations, not just on scroll.

## Changes
- Added sync call in mouse move handler for slicer3D drag mode

## Testing
- Tested with two synced canvases
- Rotation, zoom, and pan now sync correctly during drag