### PR TITLE
feat: add configurable dragAndDropSensitivity option (closes #1410)

### DIFF
--- a/packages/niivue/src/niivue/index.ts
+++ b/packages/niivue/src/niivue/index.ts
@@ -1735,7 +1735,8 @@ export class Niivue {
             currentCalMin: this.volumes[0].cal_min!,
             currentCalMax: this.volumes[0].cal_max!,
             globalMin: this.volumes[0].global_min!,
-            globalMax: this.volumes[0].global_max!
+            globalMax: this.volumes[0].global_max!,
+            sensitivity: this.opts.dragAndDropSensitivity
         })
 
         this.volumes[volIdx].cal_min = result.calMin


### PR DESCRIPTION
Highly requested feature: users can now fully control window/level drag speed!

```js
nv.opts.dragAndDropSensitivity = 0.2  // slow & precise (perfect for trackpads)
nv.opts.dragAndDropSensitivity = 5    // lightning fast (great for high-DPI mice)