### PR TITLE
Fix dark theme highlight color in the search box suggestions

### DIFF
--- a/packages/docs/src/css/custom.css
+++ b/packages/docs/src/css/custom.css
@@ -31,6 +31,7 @@
   --docusaurus-highlighted-code-line-bg: rgba(255, 255, 255, 0.1);
   --ifm-background-color: #000000; /* Black background */
   --ifm-text-color: #ffffff; /* White text */
+  --search-local-highlight-color: #798191;
 }
 
 


### PR DESCRIPTION
Minor fix to improve readability with the dark theme for the highlighted text in the search box suggestions.  It is based on the CSS properties listed here: https://github.com/easyops-cn/docusaurus-search-local?tab=readme-ov-file#custom-styles.

Before:
<img width="1505" height="588" alt="image" src="https://github.com/user-attachments/assets/172aaaf7-6087-42a2-8fe0-e334b5fc883a" />

After:
<img width="1506" height="588" alt="image" src="https://github.com/user-attachments/assets/a1a2e471-2b3b-40f1-b5fb-6bbad8ea8e66" />
 
cc @satra @ayendiki