### PR TITLE
Fix minor typo in docs

### DIFF
--- a/packages/docs/docs/colormaps2.mdx
+++ b/packages/docs/docs/colormaps2.mdx
@@ -88,7 +88,7 @@ let cmap = {
 
 ## Negative Colormaps
 
-Objects can specify both a positive and a negative color map. For example, this [voxel-based image](https://niivue.com/demos/features/alphathreshold.html) uses the `warm` colormap and the `winter` colormapNegative. Alternatively, this [mesh](https://niivue.com/demos/features/mesh.stats.html) uses the `green2orange ` colormap and the `green2cyan ` colormapNegative. This allows statistical maps to highlight correlated as well as anti-correlated contrasts.
+Objects can specify both a positive and a negative color map. For example, this [voxel-based image](https://niivue.com/demos/features/alphathreshold.html) uses the `warm` colormap and the `winter` colormapNegative. Alternatively, this [mesh](https://niivue.com/demos/features/mesh.stats.html) uses the `green2orange` colormap and the `green2cyan` colormapNegative. This allows statistical maps to highlight correlated as well as anti-correlated contrasts.
 
 ![colormapNegative](/img/pages/colormapNegative.png)
 


### PR DESCRIPTION
Currently this shows up as follows:
<img width="992" height="163" alt="image" src="https://github.com/user-attachments/assets/00e1f2bb-fed3-4b1c-a2e6-38d018a634e8" />

cc @satra @ayendiki