### PR TITLE
Add `colorbarVisible` property to `Using Colormaps` documentation page

### DIFF
--- a/packages/docs/docs/colormaps.mdx
+++ b/packages/docs/docs/colormaps.mdx
@@ -139,3 +139,10 @@ const nv = new Niivue();
 nv.opts.isColorbar = true; // or false
 nv.drawScene() // to see the changes. 
 ```
+
+If you would like to hide the colorbar for a specific volume in your canvas you can use the `colorbarVisible` property.
+
+```javascript
+nv.volumes[0].colorbarVisible = false;
+nv.updateGLVolume();
+```


### PR DESCRIPTION
The `colorbarVisible` property is described on the [Statistical Thresholding](https://niivue.com/docs/thresholding) page. Here I propose adding it to the [Using Colormaps](https://niivue.com/docs/colormaps) page so that it is easier to find.

cc @satra @ayendiki