### PR TITLE
feat(windowing): add gain factor for windowing drag sensitivity

### DIFF
--- a/packages/niivue/src/niivue/index.ts
+++ b/packages/niivue/src/niivue/index.ts
@@ -1374,8 +1374,8 @@ export class Niivue extends EventTarget {
             this.mouseDown(pos.x, pos.y)
             this.mouseClick(pos.x, pos.y)
         } else if (dragMode === DRAG_MODE.windowing) {
-            this.uiData.windowX = e.x
-            this.uiData.windowY = e.y
+            this.uiData.windowX = pos.x
+            this.uiData.windowY = pos.y
         } else {
             // Handle all other drag modes (contrast, measurement, pan, etc.)
             this.mousePos = [pos.x * this.uiData.dpr!, pos.y * this.uiData.dpr!]
@@ -1855,19 +1855,30 @@ export class Niivue extends EventTarget {
 
     /**
      * Adjusts window/level (cal_min and cal_max) based on mouse or touch drag direction.
+     * Expects x and y to be in the same coordinate space as uiData.windowX/Y
+     * (typically canvas-relative) so that deltas are consistent.
      * @internal
      */
     windowingHandler(x: number, y: number, volIdx: number = 0): void {
+        // Prevent huge delta values on the first drag when reference points
+        // are far from the current position
+        const deltaDistance = Math.sqrt((x - this.uiData.windowX) ** 2 + (y - this.uiData.windowY) ** 2)
+        if (deltaDistance > 100) {
+            this.uiData.windowX = x
+            this.uiData.windowY = y
+        }
+
         // Calculate windowing adjustments using helper
         const result = DragModeManager.calculateWindowingAdjustment({
             x,
             y,
             windowX: this.uiData.windowX,
             windowY: this.uiData.windowY,
-            currentCalMin: this.volumes[0].cal_min!,
-            currentCalMax: this.volumes[0].cal_max!,
-            globalMin: this.volumes[0].global_min!,
-            globalMax: this.volumes[0].global_max!
+            currentCalMin: this.volumes[volIdx].cal_min!,
+            currentCalMax: this.volumes[volIdx].cal_max!,
+            globalMin: this.volumes[volIdx].global_min!,
+            globalMax: this.volumes[volIdx].global_max!,
+            gainFactor: this.opts.windowingGainFactor ?? 2
         })
 
         this.volumes[volIdx].cal_min = result.calMin
@@ -2156,7 +2167,7 @@ export class Niivue extends EventTarget {
                 this.mouseClick(touchMovePos.x, touchMovePos.y)
                 this.mouseMove(touchMovePos.x, touchMovePos.y)
             } else if (dragMode === DRAG_MODE.windowing) {
-                this.windowingHandler(touchMovePos.pageX, touchMovePos.pageY)
+                this.windowingHandler(touchMovePos.x, touchMovePos.y)
                 this.drawScene()
             }
         } else {

--- a/packages/niivue/src/niivue/interaction/DragModeManager.ts
+++ b/packages/niivue/src/niivue/interaction/DragModeManager.ts
@@ -89,6 +89,7 @@ export interface CalculateWindowingParams {
     currentCalMax: number
     globalMin: number
     globalMax: number
+    gainFactor: number
 }
 
 /**
@@ -319,31 +320,40 @@ export function calculateSlicer3DZoomFromDrag(params: CalculateSlicer3DZoomParam
  * @returns Windowing result with adjusted cal_min and cal_max
  */
 export function calculateWindowingAdjustment(params: CalculateWindowingParams): WindowingAdjustmentResult {
-    const { x, y, windowX, windowY, currentCalMin, currentCalMax, globalMin, globalMax } = params
+    const { x, y, windowX, windowY, currentCalMin, currentCalMax, globalMin, globalMax, gainFactor } = params
+
+    // Ensure gainFactor is finite and non-negative to avoid propagating NaN or inverted behavior.
+    let effectiveGainFactor = Number.isFinite(gainFactor as number) ? (gainFactor as number) : 0.5
+    if (effectiveGainFactor < 0) {
+        effectiveGainFactor = 0
+    }
 
     let mn = currentCalMin
     let mx = currentCalMax
 
+    const deltaY = (y - windowY) * effectiveGainFactor
+    const deltaX = (x - windowX) * effectiveGainFactor
+
     // Adjust level based on vertical movement
-    if (y < windowY) {
+    if (deltaY < 0) {
         // increase level if mouse moves up
-        mn += 1
-        mx += 1
-    } else if (y > windowY) {
+        mn += Math.abs(deltaY)
+        mx += Math.abs(deltaY)
+    } else if (deltaY > 0) {
         // decrease level if mouse moves down
-        mn -= 1
-        mx -= 1
+        mn -= deltaY
+        mx -= deltaY
     }
 
     // Adjust window width based on horizontal movement
-    if (x > windowX) {
+    if (deltaX > 0) {
         // increase window width if mouse moves right
-        mn -= 1
-        mx += 1
-    } else if (x < windowX) {
+        mn -= deltaX
+        mx += deltaX
+    } else if (deltaX < 0) {
         // decrease window width if mouse moves left
-        mn += 1
-        mx -= 1
+        mn += Math.abs(deltaX)
+        mx -= Math.abs(deltaX)
     }
 
     // Ensure window width is at least 1

--- a/packages/niivue/src/nvdocument.ts
+++ b/packages/niivue/src/nvdocument.ts
@@ -214,6 +214,7 @@ export type NVConfigOptions = {
     bounds: [[number, number], [number, number]] | null
     showBoundsBorder?: boolean
     boundsBorderColor?: number[] // [r,g,b,a]
+    windowingGainFactor: number
     // Zarr options
     /** Chunk cache size for zarr viewing (default 500) */
     zarrCacheSize: number
@@ -334,6 +335,7 @@ export const DEFAULT_OPTIONS: NVConfigOptions = {
     bounds: null,
     showBoundsBorder: false,
     boundsBorderColor: [1, 1, 1, 1], // white border by default
+    windowingGainFactor: 2,
     // Zarr options
     zarrCacheSize: 1000,
     zarrPrefetchRings: 10,

--- a/packages/niivue/tests/unit/niivue.test.ts
+++ b/packages/niivue/tests/unit/niivue.test.ts
@@ -1,5 +1,6 @@
 import { expect, test, vi, beforeAll } from 'vitest'
 import { Niivue, PEN_TYPE, SLICE_TYPE } from '../../src/niivue/index.js' // note the js extension
+import { calculateWindowingAdjustment } from '../../src/niivue/interaction/DragModeManager.js'
 import { vec4 } from 'gl-matrix'
 
 // Mock WebGL-dependent methods
@@ -11,6 +12,50 @@ beforeAll(() => {
 test('backColor defaults to black', () => {
   const nv = new Niivue()
   expect(nv.opts.backColor).toStrictEqual([0, 0, 0, 1])
+})
+
+test('windowingGainFactor defaults to 2', () => {
+  const nv = new Niivue()
+  expect(nv.opts.windowingGainFactor).toBe(2)
+})
+
+test('windowing adjustment scales with gainFactor', () => {
+  const result = calculateWindowingAdjustment({
+    x: 10,
+    y: -5,
+    windowX: 0,
+    windowY: 0,
+    currentCalMin: 0,
+    currentCalMax: 100,
+    globalMin: -1000,
+    globalMax: 1000,
+    gainFactor: 2
+  })
+
+  expect(result.calMin).toBe(-10)
+  expect(result.calMax).toBe(130)
+})
+
+test('windowingHandler guard prevents large first-step jumps', () => {
+  const nv = new Niivue()
+  vi.spyOn(nv, 'refreshLayers').mockImplementation(() => {})
+  nv.volumes = [
+    {
+      cal_min: 0,
+      cal_max: 100,
+      global_min: -1000,
+      global_max: 1000
+    }
+  ] as never
+  nv.uiData.windowX = 0
+  nv.uiData.windowY = 0
+
+  nv.windowingHandler(200, 200)
+
+  expect(nv.volumes[0].cal_min).toBe(0)
+  expect(nv.volumes[0].cal_max).toBe(100)
+  expect(nv.uiData.windowX).toBe(200)
+  expect(nv.uiData.windowY).toBe(200)
 })
 
 test('crosshairColor can be set', async () => {


### PR DESCRIPTION
## Summary

- Add configurable `windowingGainFactor` option (default: 2) to control windowing drag sensitivity
- Scale windowing level/width adjustments by actual pixel deltas multiplied by the gain factor, instead of fixed ±1 per pixel
- Add distance guard in `windowingHandler` to prevent large jumps when reference points are far from the current drag position (e.g., on first drag)

Closes #1410