### PR TITLE
Support tensor brightness scaling using `cal_min` and `cal_max` properties

### DIFF
--- a/packages/niivue/src/niivue/index.ts
+++ b/packages/niivue/src/niivue/index.ts
@@ -6362,6 +6362,10 @@ export class Niivue {
         this.refreshColormaps()
         this.closePAQD()
         for (let i = 0; i < numLayers; i++) {
+            // refresh V1 tensor data with current cal_min/cal_max
+            if (this.volumes[i].v1) {
+                this.volumes[i].loadImgV1()
+            }
             // avoid trying to refresh a volume that isn't ready
             if (!this.volumes[i].toRAS) {
                 continue

--- a/packages/niivue/src/nvimage/TensorProcessing.ts
+++ b/packages/niivue/src/nvimage/TensorProcessing.ts
@@ -37,10 +37,7 @@ export function float32V1asRGBA(nvImage: NVImage, inImg: Float32Array): Uint8Arr
     let mn = 0.0
     let mx = 1.0
 
-    if (isFinite(nvImage.cal_min!) && isFinite(nvImage.cal_max!) && nvImage.cal_max! > nvImage.cal_min!) {
-        mn = nvImage.cal_min!
-        mx = nvImage.cal_max!
-    } else if (isFinite(nvImage.hdr.cal_min) && isFinite(nvImage.hdr.cal_max) && nvImage.hdr.cal_max > nvImage.hdr.cal_min) {
+    if (isFinite(nvImage.hdr.cal_min) && isFinite(nvImage.hdr.cal_max) && nvImage.hdr.cal_max > nvImage.hdr.cal_min) {
         mn = nvImage.hdr.cal_min
         mx = nvImage.hdr.cal_max
     } else {

--- a/packages/niivue/src/nvimage/TensorProcessing.ts
+++ b/packages/niivue/src/nvimage/TensorProcessing.ts
@@ -37,7 +37,10 @@ export function float32V1asRGBA(nvImage: NVImage, inImg: Float32Array): Uint8Arr
     let mn = 0.0
     let mx = 1.0
 
-    if (isFinite(nvImage.hdr.cal_min) && isFinite(nvImage.hdr.cal_max) && nvImage.hdr.cal_max > nvImage.hdr.cal_min) {
+    if (isFinite(nvImage.cal_min!) && isFinite(nvImage.cal_max!) && nvImage.cal_max! > nvImage.cal_min!) {
+        mn = nvImage.cal_min!
+        mx = nvImage.cal_max!
+    } else if (isFinite(nvImage.hdr.cal_min) && isFinite(nvImage.hdr.cal_max) && nvImage.hdr.cal_max > nvImage.hdr.cal_min) {
         mn = nvImage.hdr.cal_min
         mx = nvImage.hdr.cal_max
     } else {
@@ -108,6 +111,7 @@ export function loadImgV1(nvImage: NVImage, isFlipX: boolean = false, isFlipY: b
             v1[i] = -v1[i]
         }
     }
+    nvImage.v1 = v1
     nvImage.img = float32V1asRGBA(nvImage, v1)
     return true
 }

--- a/packages/niivue/src/nvimage/index.ts
+++ b/packages/niivue/src/nvimage/index.ts
@@ -80,7 +80,7 @@ export class NVImage {
     imageType?: ImageType
     img?: TypedVoxelArray
     imaginary?: Float32Array // only for complex data
-    v1?: Float32Array // only for FIB files
+    v1?: Float32Array // For FIB files or V1 vector field data
     fileObject?: File | File[]
     dims?: number[]
 


### PR DESCRIPTION
- This pull request adds the ability to modify the brightness of a tensor image that is displayed with `loadImgV1` using the `cal_min` and `cal_max` properties.
- The default behavior relies on the existing implementation of utilizing the image's maximum value.
- I tested this locally using the [modulateAfniDTI](https://github.com/niivue/niivue/blob/main/packages/niivue/demos/features/modulateAfniDTI.html) demo.  As I am new to NiiVue development, I would appreciate any further testing that you can do.  Thank you.

cc @satra @ayendiki