### PR TITLE
Feature: Adding manual pivot point

### DIFF
--- a/packages/niivue/demos/features/camera.pivot.html
+++ b/packages/niivue/demos/features/camera.pivot.html
@@ -50,16 +50,12 @@
   const pzEl = document.getElementById("pz")
 
   function updateStatus() {
-    const pivot = nv.getPivot3DPoint()
-    if (pivot) {
-      status.textContent = `Current pivot: [${pivot[0].toFixed(2)}, ${pivot[1].toFixed(2)}, ${pivot[2].toFixed(2)}]`
-    } else {
-      status.textContent = "Current pivot: auto"
-    }
+    const pivot = nv.pivot3D
+    status.textContent = `Current pivot: [${pivot[0].toFixed(2)}, ${pivot[1].toFixed(2)}, ${pivot[2].toFixed(2)}]`
   }
 
   function updateInputsFromPivot() {
-    const pivot = nv.getPivot3DPoint()
+    const pivot = nv.pivot3D
     if (pivot) {
       pxEl.value = pivot[0].toFixed(2)
       pyEl.value = pivot[1].toFixed(2)

--- a/packages/niivue/demos/features/camera.pivot.html
+++ b/packages/niivue/demos/features/camera.pivot.html
@@ -1,0 +1,106 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <title>Set 3D Pivot Point</title>
+    <link rel="stylesheet" href="light.css" />
+  </head>
+  <body style="font-family: sans-serif">
+    <header>
+      <strong>Manually set the 3D rotation pivot point.</strong>
+      <h3>Example 1: Manual Pivot Entry</h3>
+      <label for="px">Pivot X</label>
+      <input id="px" type="number" value="0" step="1" style="width: 72px" />
+      <label for="py">Y</label>
+      <input id="py" type="number" value="0" step="1" style="width: 72px" />
+      <label for="pz">Z</label>
+      <input id="pz" type="number" value="0" step="1" style="width: 72px" />
+      <button id="applyPivotBtn">Set Pivot</button>
+      <button id="clearPivotBtn">Reset to Auto</button>
+      <h3>Example 2: Pivot from Crosshair</h3>
+      <p>Click in 2D slices to move the crosshair, then use button below to set pivot to crosshair location.</p>
+      <button id="pivotCrosshairBtn">Set Pivot = Crosshair Position</button>
+      <p id="status" style="margin-top: 10px; font-weight: bold;">Current pivot: auto</p>
+    </header>
+    <main id="container">
+      <canvas id="gl"></canvas>
+    </main>
+  </body>
+</html>
+<script type="module" async>
+  import { Niivue, SHOW_RENDER } from "../dist/index.js"
+
+  const nv = new Niivue({
+    show3Dcrosshair: true,
+    dragAndDropEnabled: true
+  })
+  await nv.attachTo("gl")
+  await nv.loadVolumes([
+    { url: "../images/mni152.nii.gz", opacity: 1.0, colormap: "gray", cal_min: 30, cal_max: 80 }
+  ])
+  nv.opts.multiplanarShowRender = SHOW_RENDER.ALWAYS
+  nv.setSliceType(nv.sliceTypeMultiplanar)
+  nv.setRenderAzimuthElevation(120, 20)
+
+  const status = document.getElementById("status")
+  const pxEl = document.getElementById("px")
+  const pyEl = document.getElementById("py")
+  const pzEl = document.getElementById("pz")
+
+  function updateStatus() {
+    const pivot = nv.getPivot3DPoint()
+    if (pivot) {
+      status.textContent = `Current pivot: [${pivot[0].toFixed(2)}, ${pivot[1].toFixed(2)}, ${pivot[2].toFixed(2)}]`
+    } else {
+      status.textContent = "Current pivot: auto"
+    }
+  }
+
+  function updateInputsFromPivot() {
+    const pivot = nv.getPivot3DPoint()
+    if (pivot) {
+      pxEl.value = pivot[0].toFixed(2)
+      pyEl.value = pivot[1].toFixed(2)
+      pzEl.value = pivot[2].toFixed(2)
+    }
+  }
+
+  // Example 1: Manual pivot entry
+  document.getElementById("applyPivotBtn").onclick = () => {
+    const x = parseFloat(pxEl.value) || 0
+    const y = parseFloat(pyEl.value) || 0
+    const z = parseFloat(pzEl.value) || 0
+    nv.setPivot3DPoint([x, y, z])
+    updateStatus()
+  }
+
+  document.getElementById("clearPivotBtn").onclick = () => {
+    nv.setPivot3DPoint(null)
+    pxEl.value = "0"
+    pyEl.value = "0"
+    pzEl.value = "0"
+    updateStatus()
+  }
+
+  // Example 2: Set pivot from crosshair position
+  // Listen for crosshair location changes
+  nv.onLocationChange = (data) => {
+    // This callback fires when user clicks in 2D slices
+    updateStatus()
+  }
+
+  document.getElementById("pivotCrosshairBtn").onclick = () => {
+    if (!nv.scene?.crosshairPos) {
+      alert("No crosshair position available. Click in a 2D slice first.")
+      return
+    }
+    const mm = nv.frac2mm(nv.scene.crosshairPos)
+    nv.setPivot3DPoint([mm[0], mm[1], mm[2]])
+    updateInputsFromPivot()
+    updateStatus()
+  }
+
+  updateStatus()
+</script>

--- a/packages/niivue/demos/index.html
+++ b/packages/niivue/demos/index.html
@@ -190,6 +190,7 @@
 <li><a href="./features/scripts.html" target="_blank" rel="noopener noreferrer">User scripting</a></li>
 <li><a href="./features/shiny.volumes.html" target="_blank" rel="noopener noreferrer">Shiny volume rendering</a></li>
 <li><a href="./features/dragCallback.html" target="_blank" rel="noopener noreferrer">Dragging callbacks</a></li>
+<li><a href="./features/camera.pivot.html" target="_blank" rel="noopener noreferrer">Set camera pivot point</a></li>
 <li><a href="./features/complex.html" target="_blank" rel="noopener noreferrer">Voxels with complex numbers</a></li>
 <li><a href="./features/additive.voxels.html" target="_blank" rel="noopener noreferrer">Additive voxels</a></li>
 <li><a href="./features/additive.mesh.html" target="_blank" rel="noopener noreferrer">Additive mesh</a></li>

--- a/packages/niivue/playwright/e2e/test.niivue.depthtest.spec.ts
+++ b/packages/niivue/playwright/e2e/test.niivue.depthtest.spec.ts
@@ -5,11 +5,19 @@ import { TEST_OPTIONS } from './test.types.js'
 
 test.beforeEach(async ({ page }) => {
     await page.goto(httpServerAddress)
+    page.on('console', msg => {
+        if (msg.type() === 'timeEnd' || msg.text().includes('ms')) {
+            console.log(`Browser: ${msg.text()}`)
+        }
+    })
 })
 
 test('niivue tractography regression: mesh should respect depth test (no UI controls)', async ({ page }) => {
     const result = await page.evaluate(async (testOptions) => {
+        console.time('total-setup')
+
         // Create Niivue instance using demo-like options
+        console.time('niivue-init')
         const nv1 = new Niivue({
             ...testOptions,
             show3Dcrosshair: true,
@@ -18,27 +26,45 @@ test('niivue tractography regression: mesh should respect depth test (no UI cont
 
         nv1.opts.isColorbar = true
         nv1.setSliceType(nv1.sliceTypeRender)
+        console.timeEnd('niivue-init')
 
         // attach to canvas id "gl1"
+        console.time('attach-canvas')
         await nv1.attachTo('gl')
+        console.timeEnd('attach-canvas')
 
         // load one volume and one mesh (paths relative to served page)
+        console.time('load-volumes')
         const volumeList1 = [{ url: './images/mni152.nii.gz' }]
         await nv1.loadVolumes(volumeList1)
+        console.timeEnd('load-volumes')
 
         // load mesh (use dpsv.trx like demo)
+        console.time('load-meshes')
         await nv1.loadMeshes([{ url: './images/dpsv.trx', rgba255: [0, 142, 0, 255] }])
+        console.timeEnd('load-meshes')
 
         // set some properties similar to demo (not UI-driven)
+        console.time('set-properties')
         nv1.setMeshProperty(0, 'colormap', 'blue')
-        nv1.setMeshProperty(0, 'rgba255', [0, 255, 255, 255])
+        console.timeEnd('set-properties')
+        console.time('set-properties-1')
 
-        // set a clip plane that reveals overlap situations to expose depth issues
+        nv1.setMeshProperty(0, 'rgba255', [0, 255, 255, 255])
+      console.timeEnd('set-properties-1')
+
+      console.time('set-properties-2')
+      // set a clip plane that reveals overlap situations to expose depth issues
         nv1.setClipPlane([-0.1, 270, 0])
+        console.timeEnd('set-properties-2')
 
         // draw and finish GL to ensure the frame is rendered
+        console.time('draw-scene')
         nv1.drawScene()
         nv1.gl.finish()
+        console.timeEnd('draw-scene')
+
+        console.timeEnd('total-setup')
 
         return {
             volumes: nv1.volumes.length,

--- a/packages/niivue/playwright/e2e/test.niivue.setPivot.spec.ts
+++ b/packages/niivue/playwright/e2e/test.niivue.setPivot.spec.ts
@@ -28,22 +28,21 @@ test.describe('NiiVue setPivot3DPoint', () => {
         )
     }
 
-    test('setPivot3DPoint and getPivot3DPoint work correctly', async ({ page }) => {
+    test('setPivot3DPoint and pivot3D work correctly', async ({ page }) => {
         await setupNiivue(page)
 
         const result = await page.evaluate(() => {
             const nv = (window as unknown as { nv: Niivue }).nv
 
-            // Initial state should be null
-            const initialPivot = nv.getPivot3DPoint()
+            const initialPivot = nv.pivot3D
 
             // Set a pivot point
             nv.setPivot3DPoint([10, 20, 30])
-            const setPivot = nv.getPivot3DPoint()
+            const setPivot = nv.pivot3D
 
             // Clear the pivot point
             nv.setPivot3DPoint(null)
-            const clearedPivot = nv.getPivot3DPoint()
+            const clearedPivot = nv.pivot3D
 
             return {
                 initialPivot,
@@ -52,12 +51,13 @@ test.describe('NiiVue setPivot3DPoint', () => {
             }
         })
 
-        expect(result.initialPivot).toBeNull()
-        expect(result.setPivot).not.toBeNull()
-        expect(result.setPivot![0]).toBeCloseTo(10, 6)
-        expect(result.setPivot![1]).toBeCloseTo(20, 6)
-        expect(result.setPivot![2]).toBeCloseTo(30, 6)
-        expect(result.clearedPivot).toBeNull()
+        expect(result.setPivot[0]).toBeCloseTo(10, 6)
+        expect(result.setPivot[1]).toBeCloseTo(20, 6)
+        expect(result.setPivot[2]).toBeCloseTo(30, 6)
+        expect(result.clearedPivot[0]).toBeCloseTo(result.initialPivot[0], 6)
+        expect(result.clearedPivot[1]).toBeCloseTo(result.initialPivot[1], 6)
+        expect(result.clearedPivot[2]).toBeCloseTo(result.initialPivot[2], 6)
+
     })
 
     test('setPivot3DPoint ignores invalid values', async ({ page }) => {
@@ -68,17 +68,17 @@ test.describe('NiiVue setPivot3DPoint', () => {
 
             // Set a valid pivot
             nv.setPivot3DPoint([5, 10, 15])
-            const validPivot = nv.getPivot3DPoint()
+            const validPivot = nv.pivot3D
 
             // Try to set invalid values
             nv.setPivot3DPoint([NaN, 0, 0])
-            const afterNaN = nv.getPivot3DPoint()
+            const afterNaN = nv.pivot3D
 
             nv.setPivot3DPoint([0, Infinity, 0])
-            const afterInfinity = nv.getPivot3DPoint()
+            const afterInfinity = nv.pivot3D
 
             nv.setPivot3DPoint([0, 0, -Infinity])
-            const afterNegInfinity = nv.getPivot3DPoint()
+            const afterNegInfinity = nv.pivot3D
 
             return {
                 validPivot,
@@ -148,14 +148,14 @@ test.describe('NiiVue setPivot3DPoint', () => {
             const original: [number, number, number] = [7, 14, 21]
             nv.setPivot3DPoint(original)
 
-            const retrieved = nv.getPivot3DPoint()
+            const retrieved = nv.pivot3D
             // Modify retrieved array
             if (retrieved) {
                 retrieved[0] = 999
             }
 
             // Get again to check internal state wasn't modified
-            const retrievedAgain = nv.getPivot3DPoint()
+            const retrievedAgain = nv.pivot3D
 
             return {
                 original: original[0],

--- a/packages/niivue/playwright/e2e/test.niivue.setPivot.spec.ts
+++ b/packages/niivue/playwright/e2e/test.niivue.setPivot.spec.ts
@@ -1,0 +1,174 @@
+import { test, expect } from '@playwright/test'
+import { Niivue } from '../../dist/index.js'
+import { httpServerAddress } from './helpers.js'
+import { TEST_OPTIONS } from './test.types.js'
+
+test.beforeEach(async ({ page }) => {
+    await page.goto(httpServerAddress)
+})
+
+test.describe('NiiVue setPivot3DPoint', () => {
+    const setupNiivue = async (page) => {
+        await page.evaluate(
+            async ({ testOptions }) => {
+                const nv = new Niivue(testOptions)
+                await nv.attachTo('gl')
+                await nv.loadVolumes([
+                    {
+                        url: './images/mni152.nii.gz',
+                        colormap: 'gray',
+                        opacity: 1
+                    }
+                ])
+                nv.setSliceType(nv.sliceTypeRender)
+                nv.setRenderAzimuthElevation(110, 10)
+                ;(window as unknown as { nv: Niivue }).nv = nv
+            },
+            { testOptions: TEST_OPTIONS }
+        )
+    }
+
+    test('setPivot3DPoint and getPivot3DPoint work correctly', async ({ page }) => {
+        await setupNiivue(page)
+
+        const result = await page.evaluate(() => {
+            const nv = (window as unknown as { nv: Niivue }).nv
+
+            // Initial state should be null
+            const initialPivot = nv.getPivot3DPoint()
+
+            // Set a pivot point
+            nv.setPivot3DPoint([10, 20, 30])
+            const setPivot = nv.getPivot3DPoint()
+
+            // Clear the pivot point
+            nv.setPivot3DPoint(null)
+            const clearedPivot = nv.getPivot3DPoint()
+
+            return {
+                initialPivot,
+                setPivot,
+                clearedPivot
+            }
+        })
+
+        expect(result.initialPivot).toBeNull()
+        expect(result.setPivot).not.toBeNull()
+        expect(result.setPivot![0]).toBeCloseTo(10, 6)
+        expect(result.setPivot![1]).toBeCloseTo(20, 6)
+        expect(result.setPivot![2]).toBeCloseTo(30, 6)
+        expect(result.clearedPivot).toBeNull()
+    })
+
+    test('setPivot3DPoint ignores invalid values', async ({ page }) => {
+        await setupNiivue(page)
+
+        const result = await page.evaluate(() => {
+            const nv = (window as unknown as { nv: Niivue }).nv
+
+            // Set a valid pivot
+            nv.setPivot3DPoint([5, 10, 15])
+            const validPivot = nv.getPivot3DPoint()
+
+            // Try to set invalid values
+            nv.setPivot3DPoint([NaN, 0, 0])
+            const afterNaN = nv.getPivot3DPoint()
+
+            nv.setPivot3DPoint([0, Infinity, 0])
+            const afterInfinity = nv.getPivot3DPoint()
+
+            nv.setPivot3DPoint([0, 0, -Infinity])
+            const afterNegInfinity = nv.getPivot3DPoint()
+
+            return {
+                validPivot,
+                afterNaN,
+                afterInfinity,
+                afterNegInfinity
+            }
+        })
+
+        // All invalid attempts should leave the valid pivot unchanged
+        expect(result.validPivot![0]).toBeCloseTo(5, 6)
+        expect(result.validPivot![1]).toBeCloseTo(10, 6)
+        expect(result.validPivot![2]).toBeCloseTo(15, 6)
+
+        expect(result.afterNaN![0]).toBeCloseTo(5, 6)
+        expect(result.afterNaN![1]).toBeCloseTo(10, 6)
+        expect(result.afterNaN![2]).toBeCloseTo(15, 6)
+
+        expect(result.afterInfinity![0]).toBeCloseTo(5, 6)
+        expect(result.afterInfinity![1]).toBeCloseTo(10, 6)
+        expect(result.afterInfinity![2]).toBeCloseTo(15, 6)
+
+        expect(result.afterNegInfinity![0]).toBeCloseTo(5, 6)
+        expect(result.afterNegInfinity![1]).toBeCloseTo(10, 6)
+        expect(result.afterNegInfinity![2]).toBeCloseTo(15, 6)
+    })
+
+    test('setPivot3DPoint affects rendering pivot', async ({ page }) => {
+        await setupNiivue(page)
+
+        // Take screenshot with default pivot
+        await page.evaluate(() => {
+            const nv = (window as unknown as { nv: Niivue }).nv
+            nv.setPivot3DPoint(null)
+        })
+        await page.waitForTimeout(100)
+        const defaultPivot = await page.locator('#gl').screenshot()
+
+        // Set a custom pivot point and rotate
+        await page.evaluate(() => {
+            const nv = (window as unknown as { nv: Niivue }).nv
+            nv.setPivot3DPoint([30, -20, 10])
+            nv.setRenderAzimuthElevation(130, 25)
+        })
+        await page.waitForTimeout(100)
+        const customPivot = await page.locator('#gl').screenshot()
+
+        // Reset pivot and use the same rotation
+        await page.evaluate(() => {
+            const nv = (window as unknown as { nv: Niivue }).nv
+            nv.setPivot3DPoint(null)
+            nv.setRenderAzimuthElevation(130, 25)
+        })
+        await page.waitForTimeout(100)
+        const resetPivot = await page.locator('#gl').screenshot()
+
+        // Custom pivot should produce different rendering than reset
+        expect(customPivot).not.toEqual(resetPivot)
+    })
+
+    test('setPivot3DPoint returns a copy not a reference', async ({ page }) => {
+        await setupNiivue(page)
+
+        const result = await page.evaluate(() => {
+            const nv = (window as unknown as { nv: Niivue }).nv
+
+            const original: [number, number, number] = [7, 14, 21]
+            nv.setPivot3DPoint(original)
+
+            const retrieved = nv.getPivot3DPoint()
+            // Modify retrieved array
+            if (retrieved) {
+                retrieved[0] = 999
+            }
+
+            // Get again to check internal state wasn't modified
+            const retrievedAgain = nv.getPivot3DPoint()
+
+            return {
+                original: original[0],
+                retrieved: retrieved ? retrieved[0] : null,
+                retrievedAgain: retrievedAgain ? retrievedAgain[0] : null
+            }
+        })
+
+        // Original should be unchanged
+        expect(result.original).toBe(7)
+        // First retrieval was modified
+        expect(result.retrieved).toBe(999)
+        // Second retrieval should still be original value
+        expect(result.retrievedAgain).toBeCloseTo(7, 6)
+    })
+})

--- a/packages/niivue/src/niivue/index.ts
+++ b/packages/niivue/src/niivue/index.ts
@@ -323,8 +323,8 @@ export class Niivue extends EventTarget {
 
     otherNV: Niivue[] | null = null // another niivue instance that we wish to sync position with
     volumeObject3D: NiivueObject3D | null = null
-    pivot3D = [0, 0, 0] // center for rendering rotation
-    pivot3DPoint: [number, number, number] | null = null // optional user-specified pivot override
+    private _pivot3D: [number, number, number] = [0, 0, 0] // current center for rendering rotation
+    private pivot3DUser: [number, number, number] | null = null // optional user-specified pivot override
     furthestFromPivot = 10.0 // most distant point from pivot
 
     currentClipPlaneIndex = 0
@@ -3833,11 +3833,13 @@ if (perm[0] === 1 && perm[1] === 2 && perm[2] === 3) {
     }
 
     /**
-     * Set an optional manual 3D pivot point override.
+     * Set an optional manual 3D pivot point override, and redraw scene
      * When set to a non-null point, this value is used as the render rotation pivot.
      * Set to `null` to restore automatic pivot calculation from scene extents.
+     * Use niivue.pivot3D to get the current pivot point.
      * @param pivot3DPoint - manual pivot `[x, y, z]` in scene units, or `null` to disable override
      * @example niivue.setPivot3DPoint([0, 0, 0])
+     * @see {@link https://niivue.com/demos/features/camera.pivot.html | live demo usage}
      */
     setPivot3DPoint(pivot3DPoint: [number, number, number] | null): void {
         if (pivot3DPoint !== null) {
@@ -3845,20 +3847,20 @@ if (perm[0] === 1 && perm[1] === 2 && perm[2] === 3) {
             if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
                 return
             }
-            this.pivot3DPoint = [x, y, z]
+            this.pivot3DUser = [x, y, z]
         } else {
-            this.pivot3DPoint = null
+            this.pivot3DUser = null
         }
-        this.setPivot3D(this.pivot3DPoint)
+        this.setPivot3D()
         this.drawScene()
     }
 
     /**
-     * Get the optional manual 3D pivot point override.
-     * @returns current manual pivot `[x, y, z]`, or `null` when automatic pivot is used
+     * Get the current 3D pivot point.
+     * @returns current manual pivot `[x, y, z]`
      */
-    getPivot3DPoint(): [number, number, number] | null {
-        return this.pivot3DPoint ? [this.pivot3DPoint[0], this.pivot3DPoint[1], this.pivot3DPoint[2]] : null
+    get pivot3D(): [number, number, number] {
+        return [this._pivot3D[0], this._pivot3D[1], this._pivot3D[2]]
     }
 
     /**
@@ -9865,19 +9867,21 @@ if (perm[0] === 1 && perm[1] === 2 && perm[2] === 3) {
 
     /**
      * Sets the 3D pivot point and scene scale based on volume and mesh extents.
+     *
      * @internal
      */
-    setPivot3D(pivot3DPoint: [number, number, number] | null = this.pivot3DPoint): void {
+    setPivot3D(): void {
         // compute extents of all volumes and meshes in scene
-        // pivot around center of these.
+        // If pivot3DUser is null, calculate
+        const pivot3DUser: [number, number, number] | null = this.pivot3DUser
         const [mn, mx] = this.sceneExtentsMinMax()
         const result = SceneRenderer.calculatePivot3D({ sceneMin: mn, sceneMax: mx })
-        if (pivot3DPoint === null) {
-            this.pivot3D = result.pivot3D
+        if (pivot3DUser === null) {
+            this._pivot3D = result.pivot3D
             this.furthestFromPivot = result.furthestFromPivot
         } else {
             // Get maximum distance from pivot to any corner
-            this.pivot3D = [pivot3DPoint[0], pivot3DPoint[1], pivot3DPoint[2]]
+            this._pivot3D = [pivot3DUser[0], pivot3DUser[1], pivot3DUser[2]]
             const corners: Array<[number, number, number]> = [
                 [mn[0], mn[1], mn[2]],
                 [mn[0], mn[1], mx[2]],

--- a/packages/niivue/src/niivue/index.ts
+++ b/packages/niivue/src/niivue/index.ts
@@ -324,6 +324,7 @@ export class Niivue extends EventTarget {
     otherNV: Niivue[] | null = null // another niivue instance that we wish to sync position with
     volumeObject3D: NiivueObject3D | null = null
     pivot3D = [0, 0, 0] // center for rendering rotation
+    pivot3DPoint: [number, number, number] | null = null // optional user-specified pivot override
     furthestFromPivot = 10.0 // most distant point from pivot
 
     currentClipPlaneIndex = 0
@@ -3829,6 +3830,35 @@ if (perm[0] === 1 && perm[1] === 2 && perm[2] === 3) {
         this._emitEvent('azimuthElevationChange', { azimuth: a, elevation: e })
         this.onAzimuthElevationChange(a, e)
         this.drawScene()
+    }
+
+    /**
+     * Set an optional manual 3D pivot point override.
+     * When set to a non-null point, this value is used as the render rotation pivot.
+     * Set to `null` to restore automatic pivot calculation from scene extents.
+     * @param pivot3DPoint - manual pivot `[x, y, z]` in scene units, or `null` to disable override
+     * @example niivue.setPivot3DPoint([0, 0, 0])
+     */
+    setPivot3DPoint(pivot3DPoint: [number, number, number] | null): void {
+        if (pivot3DPoint !== null) {
+            const [x, y, z] = pivot3DPoint
+            if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
+                return
+            }
+            this.pivot3DPoint = [x, y, z]
+        } else {
+            this.pivot3DPoint = null
+        }
+        this.setPivot3D(this.pivot3DPoint)
+        this.drawScene()
+    }
+
+    /**
+     * Get the optional manual 3D pivot point override.
+     * @returns current manual pivot `[x, y, z]`, or `null` when automatic pivot is used
+     */
+    getPivot3DPoint(): [number, number, number] | null {
+        return this.pivot3DPoint ? [this.pivot3DPoint[0], this.pivot3DPoint[1], this.pivot3DPoint[2]] : null
     }
 
     /**
@@ -9837,13 +9867,37 @@ if (perm[0] === 1 && perm[1] === 2 && perm[2] === 3) {
      * Sets the 3D pivot point and scene scale based on volume and mesh extents.
      * @internal
      */
-    setPivot3D(): void {
+    setPivot3D(pivot3DPoint: [number, number, number] | null = this.pivot3DPoint): void {
         // compute extents of all volumes and meshes in scene
         // pivot around center of these.
         const [mn, mx] = this.sceneExtentsMinMax()
         const result = SceneRenderer.calculatePivot3D({ sceneMin: mn, sceneMax: mx })
-        this.pivot3D = result.pivot3D
-        this.furthestFromPivot = result.furthestFromPivot
+        if (pivot3DPoint === null) {
+            this.pivot3D = result.pivot3D
+            this.furthestFromPivot = result.furthestFromPivot
+        } else {
+            // Get maximum distance from pivot to any corner
+            this.pivot3D = [pivot3DPoint[0], pivot3DPoint[1], pivot3DPoint[2]]
+            const corners: Array<[number, number, number]> = [
+                [mn[0], mn[1], mn[2]],
+                [mn[0], mn[1], mx[2]],
+                [mn[0], mx[1], mn[2]],
+                [mn[0], mx[1], mx[2]],
+                [mx[0], mn[1], mn[2]],
+                [mx[0], mn[1], mx[2]],
+                [mx[0], mx[1], mn[2]],
+                [mx[0], mx[1], mx[2]]
+            ]
+            const pivot = vec3.fromValues(this.pivot3D[0], this.pivot3D[1], this.pivot3D[2])
+            let maxDistance = 0
+            for (const c of corners) {
+                const d = vec3.distance(pivot, vec3.fromValues(c[0], c[1], c[2]))
+                if (d > maxDistance) {
+                    maxDistance = d
+                }
+            }
+            this.furthestFromPivot = maxDistance > 0 ? maxDistance : result.furthestFromPivot
+        }
         this.extentsMin = result.extentsMin
         this.extentsMax = result.extentsMax
     }

--- a/packages/niivue/src/niivue/rendering/SceneRenderer.ts
+++ b/packages/niivue/src/niivue/rendering/SceneRenderer.ts
@@ -106,7 +106,7 @@ export interface CalculatePivot3DParams {
  * Result of pivot calculation
  */
 export interface Pivot3DResult {
-    pivot3D: number[]
+    pivot3D: [number, number, number]
     furthestFromPivot: number
     extentsMin: vec3
     extentsMax: vec3

--- a/packages/niivue/tests/unit/niivue.test.ts
+++ b/packages/niivue/tests/unit/niivue.test.ts
@@ -95,6 +95,60 @@ test('isRadiologicalConvention set by setRadiologicalConvention is tracked in do
   expect(nv.document.opts.isRadiologicalConvention).toBe(false)
 })
 
+test('setPivot3DPoint sets and getPivot3DPoint retrieves the pivot point', () => {
+  const nv = new Niivue()
+
+  // Test setting a valid pivot point
+  const pivot = [10, 20, 30] as [number, number, number]
+  nv.setPivot3DPoint(pivot)
+  const retrieved = nv.getPivot3DPoint()
+  expect(retrieved).not.toBeNull()
+  expect(retrieved![0]).toBe(10)
+  expect(retrieved![1]).toBe(20)
+  expect(retrieved![2]).toBe(30)
+
+  // Test clearing the pivot point
+  nv.setPivot3DPoint(null)
+  expect(nv.getPivot3DPoint()).toBeNull()
+})
+
+test('setPivot3DPoint ignores non-finite values', () => {
+  const nv = new Niivue()
+
+  // Set a valid pivot first
+  nv.setPivot3DPoint([1, 2, 3])
+  expect(nv.getPivot3DPoint()).not.toBeNull()
+
+  // Try to set invalid values - should be ignored
+  nv.setPivot3DPoint([NaN, 0, 0])
+  expect(nv.getPivot3DPoint()).toEqual([1, 2, 3])
+
+  nv.setPivot3DPoint([0, Infinity, 0])
+  expect(nv.getPivot3DPoint()).toEqual([1, 2, 3])
+
+  nv.setPivot3DPoint([0, 0, -Infinity])
+  expect(nv.getPivot3DPoint()).toEqual([1, 2, 3])
+})
+
+test('setPivot3DPoint returns a copy not a reference', () => {
+  const nv = new Niivue()
+  const original = [5, 10, 15] as [number, number, number]
+  nv.setPivot3DPoint(original)
+
+  const retrieved = nv.getPivot3DPoint()
+  expect(retrieved).not.toBeNull()
+
+  // Modify the retrieved array
+  retrieved![0] = 999
+
+  // Original should not be modified
+  expect(original[0]).toBe(5)
+
+  // Internal state should not be modified
+  const retrievedAgain = nv.getPivot3DPoint()
+  expect(retrievedAgain![0]).toBe(5)
+})
+
 test('isCornerOrientationText set by setCornerOrientationText is tracked in document', () => {
   const nv = new Niivue()
   nv.setCornerOrientationText(false)

--- a/packages/niivue/tests/unit/niivue.test.ts
+++ b/packages/niivue/tests/unit/niivue.test.ts
@@ -98,18 +98,21 @@ test('isRadiologicalConvention set by setRadiologicalConvention is tracked in do
 test('setPivot3DPoint sets and getPivot3DPoint retrieves the pivot point', () => {
   const nv = new Niivue()
 
+  const originalPivot = nv.pivot3D
   // Test setting a valid pivot point
   const pivot = [10, 20, 30] as [number, number, number]
   nv.setPivot3DPoint(pivot)
-  const retrieved = nv.getPivot3DPoint()
+  const retrieved = nv.pivot3D
   expect(retrieved).not.toBeNull()
-  expect(retrieved![0]).toBe(10)
-  expect(retrieved![1]).toBe(20)
-  expect(retrieved![2]).toBe(30)
+  expect(retrieved[0]).toBe(10)
+  expect(retrieved[1]).toBe(20)
+  expect(retrieved[2]).toBe(30)
 
-  // Test clearing the pivot point
+  // Test clearing the pivot point. Reset to original value
   nv.setPivot3DPoint(null)
-  expect(nv.getPivot3DPoint()).toBeNull()
+  expect(nv.pivot3D[0]).toBe(originalPivot[0])
+  expect(nv.pivot3D[1]).toBe(originalPivot[1])
+  expect(nv.pivot3D[2]).toBe(originalPivot[2])
 })
 
 test('setPivot3DPoint ignores non-finite values', () => {
@@ -117,17 +120,17 @@ test('setPivot3DPoint ignores non-finite values', () => {
 
   // Set a valid pivot first
   nv.setPivot3DPoint([1, 2, 3])
-  expect(nv.getPivot3DPoint()).not.toBeNull()
+  expect(nv.pivot3D).not.toBeNull()
 
   // Try to set invalid values - should be ignored
   nv.setPivot3DPoint([NaN, 0, 0])
-  expect(nv.getPivot3DPoint()).toEqual([1, 2, 3])
+  expect(nv.pivot3D).toEqual([1, 2, 3])
 
   nv.setPivot3DPoint([0, Infinity, 0])
-  expect(nv.getPivot3DPoint()).toEqual([1, 2, 3])
+  expect(nv.pivot3D).toEqual([1, 2, 3])
 
   nv.setPivot3DPoint([0, 0, -Infinity])
-  expect(nv.getPivot3DPoint()).toEqual([1, 2, 3])
+  expect(nv.pivot3D).toEqual([1, 2, 3])
 })
 
 test('setPivot3DPoint returns a copy not a reference', () => {
@@ -135,7 +138,7 @@ test('setPivot3DPoint returns a copy not a reference', () => {
   const original = [5, 10, 15] as [number, number, number]
   nv.setPivot3DPoint(original)
 
-  const retrieved = nv.getPivot3DPoint()
+  const retrieved = nv.pivot3D
   expect(retrieved).not.toBeNull()
 
   // Modify the retrieved array
@@ -145,7 +148,7 @@ test('setPivot3DPoint returns a copy not a reference', () => {
   expect(original[0]).toBe(5)
 
   // Internal state should not be modified
-  const retrievedAgain = nv.getPivot3DPoint()
+  const retrievedAgain = nv.pivot3D
   expect(retrievedAgain![0]).toBe(5)
 })
 


### PR DESCRIPTION
This is a minimal PR based on #1556 

It adds a basic API so that user can set the pivot point  (in the `mm` coordinate system), and adds a demo page to help potential user to user the API

API:
------
`setPivot3DPoint(pivot3DPoint: [number, number, number] | null)` : set the pivot point to required value or potentially set to null to restore automatic behavior. Silently ignore NaN or Infinite values,

`get pivot3D()`: Get the current pivot point (this existed before as a public variable, but could not be written by the user in any case, as the pivot was automatically calculated.

The reason for the mismatch between the `setPivot3D..` and the `pivot3D` is because there is already a public `setPivot3D` point (which does the heavy lifting), and I didn't want to break anything: If that is not a good enough solution, I would be happy to change as needed.

Implementation logic:
--------------------------------------

* Allow the user to set a desired pivot point `setPivot3DPoint(pivot3DPoint)`. Store in a dedicated private variable (`pivot3DUser`), and draw scene.
* `setPivot3D`: Check if the user set a (valid) pivot point, and use it. Make sure that all scene is generated by setting `furthestFromPivot` correctly (furthest corner from pivot point).

Demo page:

https://github.com/user-attachments/assets/0af77b37-b5a5-467e-b749-8d020ed4da4c





