### PR TITLE
Make isStretchToScreen pathway reachable to fix 2d view not filling entire canvas issue

### DIFF
--- a/packages/niivue/src/niivue/index.ts
+++ b/packages/niivue/src/niivue/index.ts
@@ -9740,7 +9740,12 @@ if (perm[0] === 1 && perm[1] === 2 && perm[2] === 3) {
         }
 
         if (isNaN(imageWidthHeight[0])) {
-            this.draw2DMain(ltwh, axCorSag, customMM)
+            // If original input had zero w/h (single-panel full-screen draw),
+            // pass [0,0,0,0] to draw2DMain to trigger isStretchToScreen,
+            // which expands the mm-space FoV to fill the canvas while
+            // keeping square pixels. This allows zoom to use the full canvas.
+            const wasZeroSized = leftTopWidthHeight[2] === 0 && leftTopWidthHeight[3] === 0
+            this.draw2DMain(wasZeroSized ? [0, 0, 0, 0] : ltwh, axCorSag, customMM)
         } else {
             // inset as padded in tile
             // issue1554 shift tile: do not change global padLeftTop
@@ -11862,15 +11867,9 @@ if (perm[0] === 1 && perm[1] === 2 && perm[2] === 3) {
                     }
                 }
             } else if (this.opts.sliceType === SLICE_TYPE.AXIAL || this.opts.sliceType === SLICE_TYPE.CORONAL || this.opts.sliceType === SLICE_TYPE.SAGITTAL) {
-                const { volScale } = this.sliceScale()
-
-                // full available region
-                const leftTopWidthHeight = [vpX, vpY, vpW, vpH]
-
-                // preserve mm aspect ratio
-                const actualDimensions = this.calculateWidthHeight(this.opts.sliceType, volScale, leftTopWidthHeight[2], leftTopWidthHeight[3])
-
-                this.draw2D([0, 0, 0, 0], this.opts.sliceType, NaN, actualDimensions)
+                // Pass [0,0,0,0] without actualDimensions so draw2DMain's
+                // isStretchToScreen path fills the canvas with the slice
+                this.draw2D([0, 0, 0, 0], this.opts.sliceType, NaN)
             } else {
                 // sliceTypeMultiplanar
                 let isShowRender = false


### PR DESCRIPTION
List of fixed issues (if they exist):

- #1564

This is a proposed fix to issue #1564.  However I'm not sure if this fix would have other unintended consequences.

## Cause 

1. The [single-panel draw path in `index.ts`](https://github.com/niivue/niivue/blob/f05bc78ee460f8432345bc9aa5066014b6f03d63/packages/niivue/src/niivue/index.ts#L11864) computes aspect-ratio-constrained pixel dimensions and passes them to `draw2D()`:

2. [`draw2D()`](https://github.com/niivue/niivue/blob/f05bc78ee460f8432345bc9aa5066014b6f03d63/packages/niivue/src/niivue/index.ts#L9744) uses those dimensions to shrink the viewport and center it with padding, before calling `draw2DMain()`. However, `draw2DMain()` has an [`isStretchToScreen` path](https://github.com/niivue/niivue/blob/f05bc78ee460f8432345bc9aa5066014b6f03d63/packages/niivue/src/niivue/index.ts#L9544) designed to fill the canvas by expanding the mm-space FoV to match the canvas aspect ratio, but it's unreachable. It triggers on `leftTopWidthHeight[2] === 0 || leftTopWidthHeight[3] === 0`, and `draw2D()` always resolves `[0,0,0,0]` to concrete canvas dimensions before the call.

## Fix

1. Single-panel draw path: Stop computing `actualDimensions` and pass `[0,0,0,0]` through without constraining the viewport:

2. In `draw2D()`, when `imageWidthHeight` is `NaN` and the original input was `[0,0,0,0]`, preserve it for `draw2DMain()` so `isStretchToScreen` triggers.

## Result

Before:

<img width="1902" height="1013" alt="niivue-zoom-issue-before" src="https://github.com/user-attachments/assets/42a9cd9c-4679-4e97-92a6-f727b4bffd1e" />


After:

<img width="1902" height="1013" alt="niivue-zoom-issue-after" src="https://github.com/user-attachments/assets/c1ae3f28-9110-46ae-9234-ff9b01a05ea3" />
