### PR TITLE
Fix to handle label colormaps with more than 256 entries

### DIFF
--- a/packages/niivue/src/niivue/data/VolumeColormap.ts
+++ b/packages/niivue/src/niivue/data/VolumeColormap.ts
@@ -78,6 +78,7 @@ export function setupColormapLabel(params: ColormapLabelParams): ColormapLabelRe
 
     gl.uniform1f(orientShader.uniforms.cal_min, overlayItem.colormapLabel.min! - 0.5)
     gl.uniform1f(orientShader.uniforms.cal_max, overlayItem.colormapLabel.max! + 0.5)
+    gl.uniform1i(orientShader.uniforms.isColormapLabel, 1)
     gl.bindTexture(gl.TEXTURE_2D, colormapLabelTexture)
 
     return {

--- a/packages/niivue/src/niivue/index.ts
+++ b/packages/niivue/src/niivue/index.ts
@@ -6932,6 +6932,7 @@ if (perm[0] === 1 && perm[1] === 2 && perm[2] === 3) {
             createColormapTexture: this.createColormapTexture.bind(this)
         })
         if (colormapLabelTexture === null) {
+            this.gl.uniform1i(orientShader.uniforms.isColormapLabel, 0)
             this.gl.bindTexture(this.gl.TEXTURE_2D, this.colormapTexture)
             this.gl.uniform1f(orientShader.uniforms.cal_min, overlayItem.cal_min!)
             this.gl.uniform1f(orientShader.uniforms.cal_max, overlayItem.cal_max!)

--- a/packages/niivue/src/shader-srcs.ts
+++ b/packages/niivue/src/shader-srcs.ts
@@ -1276,6 +1276,7 @@ uniform float cal_minNeg;
 uniform bool isAlphaThreshold;
 uniform bool isColorbarFromZero;
 uniform bool isAdditiveBlend;
+uniform bool isColormapLabel;
 uniform highp sampler2D colormap;
 uniform lowp sampler3D blend3D;
 uniform int modulation;
@@ -1298,7 +1299,7 @@ void main(void) {
 	float r = max(0.00001, abs(mx - mn));
 	mn = min(mn, mx);
 	float txl = mix(0.0, 1.0, (f - mn) / r);
-	if (f > mn) { //issue1139: survives threshold, so round up to opaque voxel
+	if (f > mn && !isColormapLabel) { //issue1139: survives threshold, so round up to opaque voxel
 		txl = max(txl, 2.0/256.0);
 	}
 	//https://stackoverflow.com/questions/5879403/opengl-texture-coordinates-in-pixel-space
@@ -1318,7 +1319,9 @@ void main(void) {
 		mn = min(mn, mx);
 		txl = 1.0 - mix(0.0, 1.0, (f - mn) / r);
 		//issue1139: survives threshold, so round up to opaque voxel
-		txl = max(txl, 2.0/256.0);
+		if (!isColormapLabel) {
+			txl = max(txl, 2.0/256.0);
+		}
 		y = ((2.0 * layer) + 0.5)/nlayer;
 		FragColor = texture(colormap, vec2(txl, y));
 	}


### PR DESCRIPTION
Fix to issue #1578 proposed by Claude Code.

## Summary

In `fragOrientShader`, the hardcoded clamp `txl = max(txl, 2.0/256.0)` (introduced for issue #1139) assumes a 256-entry colormap texture. When a `colormapLabel` is used with more than ~256 entries, this clamp shifts the texture lookup for low voxel values (0, 1, 2...) to the wrong label index. In practice, **label 0 (background) is never looked up** — a nearby label's color is displayed instead.

## Steps to reproduce

1. Load a base volume (e.g. a T1w image) and an atlas overlay with integer labels 0–353
2. Define a `colormapLabel` where:
   - Index 0 = transparent background `[R=0, G=0, B=0, A=0]`
   - Index 1 = red `[R=255, G=0, B=0, A=255]`
   - Index 2 = green `[R=0, G=255, B=0, A=255]`
3. Apply the colormap with `volume.setColormapLabel(cmap)` and call `nv.updateGLVolume()`

## Expected behavior

Voxels with value 0 should be **transparent**, showing the base T1w image underneath.

## Actual behavior

Voxels with value 0 appear **green** (the color of label index 2). Changing the color assigned to index 0 has no visible effect — the shader never reads that entry.

## Root cause

In `src/shader-srcs.ts`, the `fragOrientShader` contains (lines ~1301–1303):

```glsl
float txl = mix(0.0, 1.0, (f - mn) / r);
if (f > mn) { //issue1139: survives threshold, so round up to opaque voxel
    txl = max(txl, 2.0/256.0);
}
```

This clamp was added for standard 256-entry colormaps to skip reserved transparent entries at positions 0–1. However, when `setupColormapLabel()` (in `src/niivue/data/VolumeColormap.ts`) creates a label colormap texture, the texture has `nLabel` entries (e.g. 354), not 256. The `2.0/256.0` threshold then maps to a wrong pixel:

**For voxel value 0 with a 354-label colormap:**
1. `setupColormapLabel` sets `cal_min = -0.5`, `cal_max = 353.5`
2. Shader computes: `txl = (0 - (-0.5)) / 354 = 0.00141` — correctly points to texture index 0
3. But `f (0) > mn (-0.5)` is **true**, so the clamp fires: `txl = max(0.00141, 2.0/256.0) = 0.00781`
4. In a 354-pixel texture: `0.00781 × 354 ≈ 2.76` → **looks up index 2 instead of index 0**

The same clamp appears a second time at line ~1321 for the negative color path.

## Impact

- **Label 0 is unreachable**: the shader can never look up the first ~2 entries of a label colormap with >256 entries. Background voxels display a wrong (opaque) color instead of being transparent.
- **Labels 1–2 are also affected**: they are clamped to the same texture coordinate as label 0, so they all display the color of label ~2–3.
- The bug is **silent** — no console errors, just incorrect rendering.

## Proposed fix

Add a `uniform bool isColormapLabel` to the shader and skip the `2.0/256.0` clamp when rendering label colormaps. Label colormaps do not have reserved transparent entries at positions 0–1, so the clamp should not apply.

### 1. `src/shader-srcs.ts` — `fragOrientShader`

Add the uniform declaration:
```glsl
uniform bool isColormapLabel;
```

Guard both clamp occurrences:
```glsl
// Line ~1302 (positive colors)
if (f > mn && !isColormapLabel) {
    txl = max(txl, 2.0/256.0);
}

// Line ~1321 (negative colors)
if (!isColormapLabel) {
    txl = max(txl, 2.0/256.0);
}
```

### 2. `src/niivue/data/VolumeColormap.ts` — `setupColormapLabel()`

Set the uniform to `1` when a label colormap is active:
```typescript
gl.uniform1i(orientShader.uniforms.isColormapLabel, 1)
```

### 3. `src/niivue/index.ts` — regular colormap path

Reset the uniform to `0` when using a standard colormap (when `colormapLabelTexture === null`):
```typescript
this.gl.uniform1i(orientShader.uniforms.isColormapLabel, 0)
```

