### PR TITLE
fix setInterpolation docs and add getter

### DIFF
--- a/packages/docs/docs/thresholding.mdx
+++ b/packages/docs/docs/thresholding.mdx
@@ -126,13 +126,13 @@ nv.updateGLVolume();
 Interpolation can affect how thresholded values are displayed:
 
 ```javascript
-// Enable or disable interpolation
-// false = nearest neighbor (recommended for binary/thresholded data)
-// true = linear interpolation (smoother appearance)
+// Enable or disable nearest neighbor interpolation
+// true = nearest neighbor (recommended for binary/thresholded data)
+// false = linear interpolation (smoother appearance, default)
 nv.setInterpolation(true);
 ```
 
-When interpolation is enabled (default), voxels at the boundary of your threshold are smoothed, which can create a more aesthetically pleasing image but may slightly alter which voxels appear to survive thresholding.
+When nearest neighbor interpolation is disabled (default), voxels at the boundary of your threshold are smoothed, which can create a more aesthetically pleasing image but may slightly alter which voxels appear to survive thresholding.
 
 ## Working with Multiple Statistical Overlays
 

--- a/packages/niivue/src/niivue/index.ts
+++ b/packages/niivue/src/niivue/index.ts
@@ -9262,6 +9262,15 @@ if (perm[0] === 1 && perm[1] === 2 && perm[2] === 3) {
     }
 
     /**
+     * Query whether nearest neighbor interpolation is active
+     * @returns true if nearest neighbor interpolation is used, false if linear
+     * @example let isNearest = niivue.getNearestInterpolation()
+     */
+    getNearestInterpolation(): boolean {
+        return this.opts.isNearestInterpolation
+    }
+
+    /**
      * Computes 2D model-view-projection and related matrices for rendering a slice of a 3D volume.
      * Configures viewport and accounts for radiological orientation, depth clipping, and camera rotation.
      * @internal

--- a/packages/niivue/tests/unit/niivue.test.ts
+++ b/packages/niivue/tests/unit/niivue.test.ts
@@ -95,6 +95,17 @@ test('isRadiologicalConvention set by setRadiologicalConvention is tracked in do
   expect(nv.document.opts.isRadiologicalConvention).toBe(false)
 })
 
+test('isNearestInterpolation set by setInterpolation is tracked in document', () => {
+  const nv = new Niivue()
+  expect(nv.document.opts.isNearestInterpolation).toBe(false)
+  nv.setInterpolation(true)
+  expect(nv.document.opts.isNearestInterpolation).toBe(true)
+  expect(nv.getNearestInterpolation()).toBe(true)
+  nv.setInterpolation(false)
+  expect(nv.document.opts.isNearestInterpolation).toBe(false)
+  expect(nv.getNearestInterpolation()).toBe(false)
+})
+
 test('isCornerOrientationText set by setCornerOrientationText is tracked in document', () => {
   const nv = new Niivue()
   nv.setCornerOrientationText(false)


### PR DESCRIPTION
Fixes reversed true/false descriptions in setInterpolation docs and adds getNearestInterpolation() getter.

Closes #1576

The docs stated true = linear and false = nearest, but the code does the opposite. Swapped the descriptions to match the implementation. Added a getter following the getRadiologicalConvention() pattern, as suggested in the issue discussion.

**How to test:** run `npx vitest run tests/unit/niivue.test.ts` from `packages/niivue/`