### PR TITLE
fix label rendering in 2d-only and 3d-only views

### DIFF
--- a/packages/niivue/src/niivue/index.ts
+++ b/packages/niivue/src/niivue/index.ts
@@ -11762,6 +11762,7 @@ if (perm[0] === 1 && perm[1] === 2 && perm[2] === 3) {
                 if (this.opts.isColorbar) {
                     this.drawColorbar()
                 }
+                this.drawAnchoredLabels()
                 return
             }
             this.drawLoadingText(this.opts.loadingText)
@@ -11811,6 +11812,7 @@ if (perm[0] === 1 && perm[1] === 2 && perm[2] === 3) {
             if (this.opts.isColorbar) {
                 this.drawColorbar()
             }
+            this.drawAnchoredLabels()
             return
         }
 
@@ -12188,6 +12190,10 @@ if (perm[0] === 1 && perm[1] === 2 && perm[2] === 3) {
         posString = pos[0].toFixed(2) + '×' + pos[1].toFixed(2) + '×' + pos[2].toFixed(2)
         this.readyForSync = true // by the time we get here, all volumes should be loaded and ready to be drawn. We let other niivue instances know that we can now reliably sync draw calls (images are loaded)
         this.sync()
+        const has3DTile = this.screenSlices.some((s) => s.axCorSag === SLICE_TYPE.RENDER)
+        if (!has3DTile) {
+            this.draw3DLabels(mat4.create(), [0, 0, 0, 0], true)
+        }
         this.drawAnchoredLabels()
         this.drawBoundsBorder()
         return posString


### PR DESCRIPTION
Fixes labels not rendering in certain view modes.

Closes #1518

Anchored labels were missing in 3d-only and mesh-only views because drawSceneCore returned early before reaching drawAnchoredLabels. Non-anchored labels were missing in 2d-only views because draw3DLabels was only called inside draw3D.

Added drawAnchoredLabels calls before the early returns, and added a draw3DLabels call for 2d-only views when no 3d tile is present.

**How to test:**
- add a non-anchored label via addLabel, switch to axial/coronal/sagittal view, confirm it appears in the legend panel
- add an anchored label, switch to render-only view, confirm it appears