### PR TITLE
Fix Otsu thresholding on non-RAS images

### DIFF
--- a/packages/niivue/src/niivue/index.ts
+++ b/packages/niivue/src/niivue/index.ts
@@ -3535,7 +3535,7 @@ export class Niivue extends EventTarget {
             this.createEmptyDrawing()
         }
         const result = ImageProcessing.applyOtsuToDrawing({
-            img: this.volumes[0].img!,
+            img: this.volumes[0].img2RAS(),
             drawBitmap: this.drawBitmap as Uint8Array,
             thresholds
         })


### PR DESCRIPTION
Previously, when `Niivue.drawOtsu()` applied the threshold to the bitmap, it did so atop the voxel data as it exists in the source file regardless of any voxel-space transforms Niivue may be performing after loading. This change edits `drawOtsu()` to use the transformed image as returned by `img2RAS()` rather than using the raw image from the volume.

## Screenshots

I obtained these on the ["Drawing User Interface" demo](https://niivue.com/demos/features/draw.ui.html) with the LAS image already in this repository at `tests/images/nifti_space/LAS.nii.gz`.

### Before

Note the incorrect highlight on the LR:

<img width="1221" height="934" alt="image" src="https://github.com/user-attachments/assets/2233d607-6614-45b1-b566-ce613d19cd04" />

### After

The LR is fixed:

<img width="1221" height="934" alt="image" src="https://github.com/user-attachments/assets/8318cd31-12f3-41f6-823a-039c773a57ce" />

## Future work

My need (and ability to test) was only for `drawOtsu()`, but on the surface it seems some of the other functions, in particular `removeHaze()` might need a similar fix.
