### PR TITLE
Update `loadImgV1` API docs

### DIFF
--- a/packages/niivue/src/nvimage/TensorProcessing.ts
+++ b/packages/niivue/src/nvimage/TensorProcessing.ts
@@ -67,14 +67,17 @@ export function float32V1asRGBA(nvImage: NVImage, inImg: Float32Array): Uint8Arr
 }
 
 /**
- * Load and process V1 vector data with optional flips.
+ * Load and process diffusion tensor vector (V1) data with optional flips.
+ * The vectors must be of unit length.
  * Modifies the nvImage.img property with the processed RGBA data.
  *
  * @param nvImage - The NVImage instance
  * @param isFlipX - Flip X component (default: false)
  * @param isFlipY - Flip Y component (default: false)
  * @param isFlipZ - Flip Z component (default: false)
+ * @example nv1.loadVolumes(volumeList); nv1.volumes[1].loadImgV1();
  * @returns true if successful, false if V1 data is not available
+ * @see {@link https://niivue.com/demos/features/modulate.html | live demo usage}
  */
 export function loadImgV1(nvImage: NVImage, isFlipX: boolean = false, isFlipY: boolean = false, isFlipZ: boolean = false): boolean {
     let v1 = nvImage.v1

--- a/packages/niivue/src/nvimage/index.ts
+++ b/packages/niivue/src/nvimage/index.ts
@@ -427,10 +427,29 @@ export class NVImage {
         return ImageOrientation.computeObliqueAngle(mtx44)
     }
 
+    /**
+     * Convert vector field from Float32 to RGBA representation.
+     * Note: We use RGBA rather than RGB and use least significant bits to store vector polarity.
+     * This allows a single bitmap to store BOTH (unsigned) color magnitude and signed vector direction.
+     *
+     * @param nvImage - The NVImage instance
+     * @param inImg - Input Float32Array containing vector field data
+     * @returns Uint8Array with RGBA encoded vector data
+     */
     float32V1asRGBA(inImg: Float32Array): Uint8Array {
         return TensorProcessing.float32V1asRGBA(this, inImg)
     }
 
+    /**
+     * Load and process V1 vector data with optional flips.
+     * Modifies the nvImage.img property with the processed RGBA data.
+     *
+     * @param nvImage - The NVImage instance
+     * @param isFlipX - Flip X component (default: false)
+     * @param isFlipY - Flip Y component (default: false)
+     * @param isFlipZ - Flip Z component (default: false)
+     * @returns true if successful, false if V1 data is not available
+     */
     loadImgV1(isFlipX: boolean = false, isFlipY: boolean = false, isFlipZ: boolean = false): boolean {
         return TensorProcessing.loadImgV1(this, isFlipX, isFlipY, isFlipZ)
     }

--- a/packages/niivue/src/nvimage/index.ts
+++ b/packages/niivue/src/nvimage/index.ts
@@ -441,14 +441,17 @@ export class NVImage {
     }
 
     /**
-     * Load and process V1 vector data with optional flips.
+     * Load and process diffusion tensor vector (V1) data with optional flips.
+     * The vectors must be of unit length.
      * Modifies the nvImage.img property with the processed RGBA data.
      *
      * @param nvImage - The NVImage instance
      * @param isFlipX - Flip X component (default: false)
      * @param isFlipY - Flip Y component (default: false)
      * @param isFlipZ - Flip Z component (default: false)
+     * @example nv1.loadVolumes(volumeList); nv1.volumes[1].loadImgV1();
      * @returns true if successful, false if V1 data is not available
+     * @see {@link https://niivue.com/demos/features/modulate.html | live demo usage}
      */
     loadImgV1(isFlipX: boolean = false, isFlipY: boolean = false, isFlipZ: boolean = false): boolean {
         return TensorProcessing.loadImgV1(this, isFlipX, isFlipY, isFlipZ)


### PR DESCRIPTION
- Although `TensorProcessing.ts` has a docstring, it does not show up on the [API docs](https://niivue.com/docs/api/nvimage/classes/NVImage?_highlight=loadimgv1#loadimgv1).  So I have copied the docstrings for `float32V1asRGBA` and `loadImgV1` to `packages/niivue/src/nvimage/index.ts` so that they show up on the NiiVue documentation site.
- Also, I have updated the `loadImgV1` docs with an additional note, example usage, and a link to the live demo.

Thanks.

cc @ayendiki @satra