### PR TITLE
fix: correct reversed translucent/transparent volume rendering (#1594)

### DIFF
--- a/packages/niivue/src/niivue/data/VolumeLayerRenderer.ts
+++ b/packages/niivue/src/niivue/data/VolumeLayerRenderer.ts
@@ -4,6 +4,7 @@
  */
 
 import { mat4, vec3 } from 'gl-matrix'
+import { COLORMAP_TYPE } from '@/colortables'
 import { NVImage } from '@/nvimage'
 import { NiivueObject3D } from '@/niivue-object3D'
 import { toNiivueObject3D } from '@/nvimage/RenderingUtils'
@@ -209,7 +210,7 @@ export function configureColormapUniforms(params: ConfigureColormapUniformsParam
 
     // Handle colormap type
     const isColorbarFromZero = overlayItem.colormapType !== 0 ? 1 : 0 // COLORMAP_TYPE.MIN_TO_MAX = 0
-    const isAlphaThreshold = overlayItem.colormapType === 1 ? 1 : 0 // COLORMAP_TYPE.ZERO_TO_MAX_TRANSLUCENT_BELOW_MIN = 1
+    const isAlphaThreshold = overlayItem.colormapType === COLORMAP_TYPE.ZERO_TO_MAX_TRANSLUCENT_BELOW_MIN ? 1 : 0
 
     gl.uniform1i(orientShader.uniforms.isAlphaThreshold, isAlphaThreshold)
     gl.uniform1i(orientShader.uniforms.isColorbarFromZero, isColorbarFromZero)

--- a/packages/niivue/tests/unit/volumeLayerRenderer.test.ts
+++ b/packages/niivue/tests/unit/volumeLayerRenderer.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+import { expect, test, vi } from 'vitest'
+import { configureColormapUniforms } from '../../src/niivue/data/VolumeLayerRenderer.js'
+import { COLORMAP_TYPE } from '../../src/colortables.js'
+
+/**
+ * Regression test for niivue issue #1594
+ * ("Transparent and translucent subthreshold rendering seem reversed").
+ *
+ * The fragment shader's `isAlphaThreshold` uniform drives the TRANSLUCENT
+ * (graded partial-alpha) branch, so it must be 1 ONLY for
+ * COLORMAP_TYPE.ZERO_TO_MAX_TRANSLUCENT_BELOW_MIN (value 2), and 0 for both
+ * MIN_TO_MAX (0) and ZERO_TO_MAX_TRANSPARENT_BELOW_MIN (1).
+ */
+
+// Sentinel uniform location used to assert the spy was called with the
+// isAlphaThreshold location specifically (not some other uniform).
+const ISALPHATHRESHOLD_LOC = 'LOC_isAlphaThreshold'
+
+function buildMocks(colormapType: COLORMAP_TYPE): {
+  gl: { uniform1i: ReturnType<typeof vi.fn>; uniform1f: ReturnType<typeof vi.fn> }
+  orientShader: { uniforms: Record<string, string> }
+  overlayItem: Record<string, unknown>
+} {
+  const gl = {
+    uniform1i: vi.fn(),
+    uniform1f: vi.fn()
+  }
+
+  const orientShader = {
+    uniforms: {
+      isAlphaThreshold: ISALPHATHRESHOLD_LOC,
+      isColorbarFromZero: 'LOC_isColorbarFromZero',
+      isAdditiveBlend: 'LOC_isAdditiveBlend',
+      layer: 'LOC_layer',
+      cal_minNeg: 'LOC_cal_minNeg',
+      cal_maxNeg: 'LOC_cal_maxNeg'
+    }
+  }
+
+  // Empty colormapNegative skips the negative-colormap branch, so cal_min/cal_max
+  // are never read. We still provide them as finite numbers for completeness.
+  const overlayItem = {
+    colormapType,
+    colormapNegative: [],
+    cal_min: 0,
+    cal_max: 1,
+    cal_minNeg: Number.NaN,
+    cal_maxNeg: Number.NaN
+  }
+
+  return { gl, orientShader, overlayItem }
+}
+
+function callConfigure(colormapType: COLORMAP_TYPE): {
+  gl: { uniform1i: ReturnType<typeof vi.fn>; uniform1f: ReturnType<typeof vi.fn> }
+  orientShader: { uniforms: Record<string, string> }
+} {
+  const { gl, orientShader, overlayItem } = buildMocks(colormapType)
+  configureColormapUniforms({
+    gl: gl as any,
+    overlayItem: overlayItem as any,
+    orientShader: orientShader as any,
+    layer: 1,
+    isAdditiveBlend: false
+  })
+  return { gl, orientShader }
+}
+
+test('isAlphaThreshold is 1 for ZERO_TO_MAX_TRANSLUCENT_BELOW_MIN (translucent)', () => {
+  const { gl, orientShader } = callConfigure(COLORMAP_TYPE.ZERO_TO_MAX_TRANSLUCENT_BELOW_MIN)
+  expect(gl.uniform1i).toHaveBeenCalledWith(orientShader.uniforms.isAlphaThreshold, 1)
+})
+
+test('isAlphaThreshold is 0 for ZERO_TO_MAX_TRANSPARENT_BELOW_MIN (transparent)', () => {
+  const { gl, orientShader } = callConfigure(COLORMAP_TYPE.ZERO_TO_MAX_TRANSPARENT_BELOW_MIN)
+  expect(gl.uniform1i).toHaveBeenCalledWith(orientShader.uniforms.isAlphaThreshold, 0)
+  expect(gl.uniform1i).not.toHaveBeenCalledWith(orientShader.uniforms.isAlphaThreshold, 1)
+})
+
+test('isAlphaThreshold is 0 for MIN_TO_MAX', () => {
+  const { gl, orientShader } = callConfigure(COLORMAP_TYPE.MIN_TO_MAX)
+  expect(gl.uniform1i).toHaveBeenCalledWith(orientShader.uniforms.isAlphaThreshold, 0)
+  expect(gl.uniform1i).not.toHaveBeenCalledWith(orientShader.uniforms.isAlphaThreshold, 1)
+})
+
+test('isColorbarFromZero is unaffected: 1 for both threshold types, 0 for MIN_TO_MAX', () => {
+  // Guards against regressing the (correct) sibling line 211.
+  const translucent = callConfigure(COLORMAP_TYPE.ZERO_TO_MAX_TRANSLUCENT_BELOW_MIN)
+  expect(translucent.gl.uniform1i).toHaveBeenCalledWith(translucent.orientShader.uniforms.isColorbarFromZero, 1)
+  expect(translucent.gl.uniform1i).not.toHaveBeenCalledWith(translucent.orientShader.uniforms.isColorbarFromZero, 0)
+
+  const transparent = callConfigure(COLORMAP_TYPE.ZERO_TO_MAX_TRANSPARENT_BELOW_MIN)
+  expect(transparent.gl.uniform1i).toHaveBeenCalledWith(transparent.orientShader.uniforms.isColorbarFromZero, 1)
+  expect(transparent.gl.uniform1i).not.toHaveBeenCalledWith(transparent.orientShader.uniforms.isColorbarFromZero, 0)
+
+  const minToMax = callConfigure(COLORMAP_TYPE.MIN_TO_MAX)
+  expect(minToMax.gl.uniform1i).toHaveBeenCalledWith(minToMax.orientShader.uniforms.isColorbarFromZero, 0)
+  expect(minToMax.gl.uniform1i).not.toHaveBeenCalledWith(minToMax.orientShader.uniforms.isColorbarFromZero, 1)
+})


### PR DESCRIPTION
Closes #1594.

NiiVue's volume colormap types `ZERO_TO_MAX_TRANSPARENT_BELOW_MIN` (1) and `ZERO_TO_MAX_TRANSLUCENT_BELOW_MIN` (2) rendered swapped: selecting *transparent* produced translucent subthreshold voxels and vice-versa.

## Root cause
In `configureColormapUniforms` (`VolumeLayerRenderer.ts`), the shader's `isAlphaThreshold` uniform (which drives the translucent, graded partial-alpha ramp `pow(v/cal_min, 2)`) was set for `colormapType === 1` — i.e. for the **transparent** type — instead of value `2` (translucent). The inline comment was itself mislabeled (`= 1`), which looks like the original off-by-one slip.

## Fix
Compare against the enum constant so the translucent ramp is driven by the translucent type:
```ts
const isAlphaThreshold = overlayItem.colormapType === COLORMAP_TYPE.ZERO_TO_MAX_TRANSLUCENT_BELOW_MIN ? 1 : 0
```
Scope: **only the volume rendering path** was affected. The mesh path (`nvmesh.ts`) already keyed translucency off `ZERO_TO_MAX_TRANSLUCENT_BELOW_MIN` (value 2) with the same ramp, and is unchanged. `isColorbarFromZero` (correct for both threshold types) is unchanged. The public thresholding docs and the legacy `alphaThreshold` shim already describe value 2 as translucent, so this fix makes the volume path match the documented behavior.

## Test
Added `tests/unit/volumeLayerRenderer.test.ts` (vitest, node env, no WebGL): asserts the `isAlphaThreshold` uniform is `1` only for `ZERO_TO_MAX_TRANSLUCENT_BELOW_MIN` and `0` for the transparent and min-to-max types, with a guard that `isColorbarFromZero` is unaffected. The test fails on the previous `=== 1` logic and passes with the fix.
