### PR TITLE
perf: cache the raw volume texture across refreshLayers calls

### DIFF
--- a/packages/niivue/src/niivue/data/VolumeLayerRenderer.ts
+++ b/packages/niivue/src/niivue/data/VolumeLayerRenderer.ts
@@ -474,13 +474,28 @@ export interface SetupVolumeTextureDataResult {
 }
 
 /**
- * Setup volume texture data based on datatype.
- * Allocates GPU texture storage, transfers image data, and selects appropriate shader.
- * @param params - Setup parameters
+ * Parameters for selecting the orient shader for non-RGBA32 volume data
+ */
+export interface SelectVolumeOrientShaderParams {
+    gl: WebGL2RenderingContext
+    hdr: any
+    orientShaderU: Shader
+    orientShaderI: Shader
+    orientShaderF: Shader
+    orientShaderRGBU: Shader
+    orientShaderAtlasU: Shader
+    orientShaderAtlasI: Shader
+}
+
+/**
+ * Select the orient shader matching the volume datatype and intent code.
+ * Shared by setupVolumeTextureData() and the cached-texture path in
+ * refreshLayers(), which skips the GPU upload but still needs the shader.
+ * @param params - Shader selection parameters
  * @returns Selected orient shader
  */
-export function setupVolumeTextureData(params: SetupVolumeTextureDataParams): SetupVolumeTextureDataResult {
-    const { gl, hdr, img, orientShaderU, orientShaderI, orientShaderF, orientShaderRGBU, orientShaderAtlasU, orientShaderAtlasI } = params
+export function selectVolumeOrientShader(params: SelectVolumeOrientShaderParams): Shader {
+    const { gl, hdr, orientShaderU, orientShaderI, orientShaderF, orientShaderRGBU, orientShaderAtlasU, orientShaderAtlasI } = params
 
     let orientShader = orientShaderU
 
@@ -488,34 +503,55 @@ export function setupVolumeTextureData(params: SetupVolumeTextureDataParams): Se
         if (hdr.intent_code === NII_INTENT_LABEL) {
             orientShader = orientShaderAtlasU
         }
-        gl.texStorage3D(gl.TEXTURE_3D, 1, gl.R8UI, hdr.dims[1], hdr.dims[2], hdr.dims[3])
-        gl.texSubImage3D(gl.TEXTURE_3D, 0, 0, 0, 0, hdr.dims[1], hdr.dims[2], hdr.dims[3], gl.RED_INTEGER, gl.UNSIGNED_BYTE, img)
     } else if (hdr.datatypeCode === NII_DT_INT16) {
         orientShader = orientShaderI
         if (hdr.intent_code === NII_INTENT_LABEL) {
             orientShader = orientShaderAtlasI
         }
+    } else if (hdr.datatypeCode === NII_DT_FLOAT32 || hdr.datatypeCode === NII_DT_FLOAT64) {
+        orientShader = orientShaderF
+    } else if (hdr.datatypeCode === NII_DT_RGB24) {
+        orientShader = orientShaderRGBU
+        orientShader.use(gl)
+        // orientShaderRGBU is shared with the RGBA32 path, which sets hasAlpha to 1
+        gl.uniform1i(orientShader.uniforms.hasAlpha, 0)
+    } else if (hdr.datatypeCode === NII_DT_UINT16) {
+        if (hdr.intent_code === NII_INTENT_LABEL) {
+            orientShader = orientShaderAtlasU
+        }
+    }
+
+    return orientShader
+}
+
+/**
+ * Setup volume texture data based on datatype.
+ * Allocates GPU texture storage, transfers image data, and selects appropriate shader.
+ * @param params - Setup parameters
+ * @returns Selected orient shader
+ */
+export function setupVolumeTextureData(params: SetupVolumeTextureDataParams): SetupVolumeTextureDataResult {
+    const { gl, hdr, img } = params
+
+    const orientShader = selectVolumeOrientShader(params)
+
+    if (hdr.datatypeCode === NII_DT_UINT8) {
+        gl.texStorage3D(gl.TEXTURE_3D, 1, gl.R8UI, hdr.dims[1], hdr.dims[2], hdr.dims[3])
+        gl.texSubImage3D(gl.TEXTURE_3D, 0, 0, 0, 0, hdr.dims[1], hdr.dims[2], hdr.dims[3], gl.RED_INTEGER, gl.UNSIGNED_BYTE, img)
+    } else if (hdr.datatypeCode === NII_DT_INT16) {
         gl.texStorage3D(gl.TEXTURE_3D, 1, gl.R16I, hdr.dims[1], hdr.dims[2], hdr.dims[3])
         gl.texSubImage3D(gl.TEXTURE_3D, 0, 0, 0, 0, hdr.dims[1], hdr.dims[2], hdr.dims[3], gl.RED_INTEGER, gl.SHORT, img)
     } else if (hdr.datatypeCode === NII_DT_FLOAT32) {
         gl.texStorage3D(gl.TEXTURE_3D, 1, gl.R32F, hdr.dims[1], hdr.dims[2], hdr.dims[3])
         gl.texSubImage3D(gl.TEXTURE_3D, 0, 0, 0, 0, hdr.dims[1], hdr.dims[2], hdr.dims[3], gl.RED, gl.FLOAT, img)
-        orientShader = orientShaderF
     } else if (hdr.datatypeCode === NII_DT_FLOAT64) {
         const img32f = Float32Array.from(img)
         gl.texStorage3D(gl.TEXTURE_3D, 1, gl.R32F, hdr.dims[1], hdr.dims[2], hdr.dims[3])
         gl.texSubImage3D(gl.TEXTURE_3D, 0, 0, 0, 0, hdr.dims[1], hdr.dims[2], hdr.dims[3], gl.RED, gl.FLOAT, img32f)
-        orientShader = orientShaderF
     } else if (hdr.datatypeCode === NII_DT_RGB24) {
-        orientShader = orientShaderRGBU
-        orientShader.use(gl)
-        gl.uniform1i(orientShader.uniforms.hasAlpha, 0)
         gl.texStorage3D(gl.TEXTURE_3D, 1, gl.RGB8UI, hdr.dims[1], hdr.dims[2], hdr.dims[3])
         gl.texSubImage3D(gl.TEXTURE_3D, 0, 0, 0, 0, hdr.dims[1], hdr.dims[2], hdr.dims[3], gl.RGB_INTEGER, gl.UNSIGNED_BYTE, img)
     } else if (hdr.datatypeCode === NII_DT_UINT16) {
-        if (hdr.intent_code === NII_INTENT_LABEL) {
-            orientShader = orientShaderAtlasU
-        }
         gl.texStorage3D(gl.TEXTURE_3D, 1, gl.R16UI, hdr.dims[1], hdr.dims[2], hdr.dims[3])
         gl.texSubImage3D(gl.TEXTURE_3D, 0, 0, 0, 0, hdr.dims[1], hdr.dims[2], hdr.dims[3], gl.RED_INTEGER, gl.UNSIGNED_SHORT, img)
     }

--- a/packages/niivue/src/niivue/index.ts
+++ b/packages/niivue/src/niivue/index.ts
@@ -60,7 +60,7 @@ import {
 } from '@/nvdocument'
 import { LabelTextAlignment, LabelLineTerminator, NVLabel3D, NVLabel3DStyle, LabelAnchorPoint, LabelAnchorFlag } from '@/nvlabel'
 import { FreeSurferConnectome, NVConnectome } from '@/nvconnectome'
-import { NVImage, NVImageFromUrlOptions, NiiDataType, NiiIntentCode, ImageFromUrlOptions } from '@/nvimage'
+import { NVImage, NVImageFromUrlOptions, NiiDataType, NiiIntentCode, ImageFromUrlOptions, TypedVoxelArray } from '@/nvimage'
 import { AffineTransform } from '@/nvimage/affineUtils'
 import { NVUtilities } from '@/nvutilities'
 import { NiivueEventMap, NiivueEvent, NiivueEventListener, NiivueEventListenerOptions } from '@/events'
@@ -196,6 +196,10 @@ export class Niivue extends EventTarget {
     colormapTexture: WebGLTexture | null = null // the GPU memory storage of the colormap
     colormapLists: ColormapListEntry[] = [] // one entry per colorbar: min, max, tic
     volumeTexture: WebGLTexture | null = null // the GPU memory storage of the volume
+    // per-layer cache of the raw (pre-orient) volume texture: refreshLayers() runs on every
+    // display-parameter change (cal_min/cal_max, opacity, colormap), but the voxel data only
+    // changes when the img array or the displayed 4D frame does - reuse the uploaded texture
+    rawVolumeTextureCache: Map<number, { tex: WebGLTexture; src: TypedVoxelArray; frame4D: number }> = new Map()
     gradientTexture: WebGLTexture | null = null // 3D texture for volume rendering lighting
     gradientTextureAmount = 0.0
     useCustomGradientTexture = false // flag to indicate if a custom gradient texture is used
@@ -6727,6 +6731,13 @@ if (perm[0] === 1 && perm[1] === 2 && perm[2] === 3) {
             this.refreshLayers(this.volumes[i], visibleLayers)
             visibleLayers++
         }
+        // free cached raw volume textures of layers that no longer exist
+        for (const [cachedLayer, cached] of this.rawVolumeTextureCache) {
+            if (cachedLayer >= visibleLayers) {
+                this.gl.deleteTexture(cached.tex)
+                this.rawVolumeTextureCache.delete(cachedLayer)
+            }
+        }
         this.furthestVertexFromOrigin = 0.0
         if (numLayers > 0) {
             this.furthestVertexFromOrigin = this.volumeObject3D?.furthestVertexFromOrigin ?? 0
@@ -6956,11 +6967,28 @@ if (perm[0] === 1 && perm[1] === 2 && perm[2] === 3) {
         const fb = VolumeLayerRenderer.setupFramebuffer(this.gl)
         this.gl.viewport(0, 0, this.back.dims![1], this.back.dims![2]) // output in background dimensions
 
-        // Create temporary 3D texture for volume data
-        const tempTex3D = VolumeLayerRenderer.createTemporaryTexture({
-            gl: this.gl,
-            TEXTURE9_ORIENT: TEXTURE_CONSTANTS.TEXTURE9_ORIENT
-        })
+        // Reuse the raw volume texture when the voxel data is unchanged: refreshLayers()
+        // also runs for display-parameter changes (cal_min/cal_max, opacity, colormap),
+        // where re-converting and re-uploading the full volume is wasted work.
+        // RGBA32 volumes are excluded: their upload path mutates shared PAQD state.
+        const cachedRawTexture = this.rawVolumeTextureCache.get(layer)
+        const canReuseRawTexture = !!cachedRawTexture && cachedRawTexture.src === overlayItem.img && cachedRawTexture.frame4D === overlayItem.frame4D && hdr.datatypeCode !== NiiDataType.DT_RGBA32
+        let tempTex3D: WebGLTexture | null
+        if (canReuseRawTexture) {
+            tempTex3D = cachedRawTexture.tex
+            this.gl.activeTexture(TEXTURE_CONSTANTS.TEXTURE9_ORIENT)
+            this.gl.bindTexture(this.gl.TEXTURE_3D, tempTex3D)
+        } else {
+            if (cachedRawTexture) {
+                this.gl.deleteTexture(cachedRawTexture.tex)
+                this.rawVolumeTextureCache.delete(layer)
+            }
+            // Create temporary 3D texture for volume data
+            tempTex3D = VolumeLayerRenderer.createTemporaryTexture({
+                gl: this.gl,
+                TEXTURE9_ORIENT: TEXTURE_CONSTANTS.TEXTURE9_ORIENT
+            })
+        }
 
         if (!hdr) {
             throw new Error('hdr undefined')
@@ -6995,6 +7023,18 @@ if (perm[0] === 1 && perm[1] === 2 && perm[2] === 3) {
             if (rgba32Result.paqdTexture !== null) {
                 this.paqdTexture = rgba32Result.paqdTexture
             }
+        } else if (canReuseRawTexture) {
+            // Voxel data already on the GPU: select the matching shader without re-uploading
+            orientShader = VolumeLayerRenderer.selectVolumeOrientShader({
+                gl: this.gl,
+                hdr,
+                orientShaderU: this.orientShaderU!,
+                orientShaderI: this.orientShaderI!,
+                orientShaderF: this.orientShaderF!,
+                orientShaderRGBU: this.orientShaderRGBU!,
+                orientShaderAtlasU: this.orientShaderAtlasU!,
+                orientShaderAtlasI: this.orientShaderAtlasI!
+            })
         } else {
             // All other datatypes
             const uploadResult = VolumeLayerRenderer.setupVolumeTextureData({
@@ -7009,6 +7049,7 @@ if (perm[0] === 1 && perm[1] === 2 && perm[2] === 3) {
                 orientShaderAtlasI: this.orientShaderAtlasI!
             })
             orientShader = uploadResult.orientShader
+            this.rawVolumeTextureCache.set(layer, { tex: tempTex3D!, src: overlayItem.img!, frame4D: overlayItem.frame4D })
         }
         if (overlayItem.global_min === undefined) {
             // only once, first time volume is loaded
@@ -7098,7 +7139,10 @@ if (perm[0] === 1 && perm[1] === 2 && perm[2] === 3) {
         })
         log.debug('back dims: ', this.back.dims)
         this.gl.bindVertexArray(this.unusedVAO)
-        this.gl.deleteTexture(tempTex3D)
+        const retainedRawTexture = this.rawVolumeTextureCache.get(layer)
+        if (!retainedRawTexture || retainedRawTexture.tex !== tempTex3D) {
+            this.gl.deleteTexture(tempTex3D)
+        }
         this.gl.deleteTexture(modulateTexture)
         this.gl.deleteTexture(blendTexture)
         this.gl.viewport(0, 0, this.gl.canvas.width, this.gl.canvas.height)


### PR DESCRIPTION
# perf: cache the raw volume texture across refreshLayers calls

`updateGLVolume()` runs on many display-only interactions (window/level, opacity, colormap changes). Each call rebuilt and re-uploaded the full raw 3D volume texture even though the voxel data hadn't changed. For large volumes, and float64 volumes in particular, that means a full `Float32Array.from(...)` conversion plus a large CPU-to-GPU upload on every slider tick, which causes visible stalls.

This PR reuses the already-uploaded raw texture when the source voxel data is unchanged, so display-only updates only re-run the orient pass.

Not going to hide that this change was made using help of Claude, but it did help with the performance of our personal project, so I figured it may be worth a review.

## Changes

- `Niivue` keeps a per-layer cache of the raw 3D texture, keyed by the source `img` array reference and `frame4D`.
- In `refreshLayers()`, if the cache entry matches (same `img` reference, same `frame4D`, datatype is not `DT_RGBA32`), the existing raw texture is reused and the conversion/upload is skipped. On a miss, the previous upload path runs and the cache entry is replaced.
- Orient-shader selection was extracted into `VolumeLayerRenderer.selectVolumeOrientShader()` so it can run on cache hits without going through the upload path.
- Cached textures are no longer unconditionally deleted at the end of `refreshLayers()`. Stale entries are deleted when a layer is re-uploaded, and entries for removed layers are swept in `updateGLVolume()`.
- `DT_RGBA32` is excluded from reuse because the PAQD handling has side effects in the upload path that must still run.

Display parameters (`cal_min`/`cal_max`, opacity, colormap) are applied as orient-pass uniforms, so they stay correct while the raw upload is skipped. The orient pass and everything downstream are unchanged.

## Benchmarks

Measured with an interleaved A/B harness (Chromium 143 headless, i5-8365U / UHD 620, Linux) on a float64-heavy CBCT dataset (ToothFairy3). Baseline is `main` at a04235c8, candidate is this branch. Final-frame checksums are identical between baseline and candidate in every scenario.

| Scenario | Volume | Baseline median | This PR | Speedup |
|---|---|---:|---:|---:|
| cold_load | small | 1249 ms | 1200 ms | 1.04x |
| cold_load | medium | 2536 ms | 2439 ms | 1.04x |
| cold_load | large | 6796 ms | 6615 ms | 1.03x |
| intensity_sweep | small | 319 ms | 190 ms | 1.68x |
| intensity_sweep | medium | 657 ms | 473 ms | 1.39x |
| intensity_sweep | large | 1489 ms | 1003 ms | 1.49x |
| opacity_sweep | medium | 604 ms | 412 ms | 1.47x |
| colormap_cycle | medium | 1389 ms | 1230 ms | 1.13x |
| overlay_intensity_sweep | overlay | 301 ms | 214 ms | 1.41x |

The wins are concentrated where expected: repeated display-only updates run 1.4–1.7x faster, while cold load is near-neutral since the first upload still has to happen.

## Trade-offs

- VRAM usage goes up: one raw texture per cached layer stays resident between refreshes.
- Invalidation is identity-based. Mutating `img` in place without replacing the array reference will keep serving the stale texture. This matches how NiiVue replaces volume data today, but it's a constraint worth knowing.
- Not benchmarked: 4D frame-switch-heavy workloads, the `DT_RGBA32`/PAQD path (intentionally bypassed), and datatypes beyond the float64-dominant dataset.

A reasonable follow-up would be unit/integration coverage for cache invalidation around `frame4D` changes and layer removal.