### PR TITLE
Fix Zenodo DOI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 > [!IMPORTANT]
 > **NiiVue is moving to [niivue/mono](https://github.com/niivue/mono).** The new monorepo contains a rewritten `@niivue/niivue` package with WebGPU and WebGL2 support, smaller bundle sizes, and a more extensible architecture. The monorepo package will be our **v1.0.0** release candidate. All releases in this repository will remain below v1.0.0 so the two packages can co-exist. Most functionality has been ported and new development will focus on the monorepo. We will continue to maintain this repository for a transition period, but encourage users to migrate when ready.
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5786269.svg)](https://doi.org/10.5281/zenodo.5786269) [![App Store](https://img.shields.io/badge/App%20Store-NiiVue-blue)](https://apps.apple.com/gb/app/niivue/id6497066801) [![npm](https://img.shields.io/npm/v/@niivue/niivue)](https://www.npmjs.com/package/@niivue/niivue)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.5786269-blue)](https://doi.org/10.5281/zenodo.5786269) [![App Store](https://img.shields.io/badge/App%20Store-NiiVue-blue)](https://apps.apple.com/gb/app/niivue/id6497066801) [![npm](https://img.shields.io/npm/v/@niivue/niivue)](https://www.npmjs.com/package/@niivue/niivue)
 
 # NiiVue
 


### PR DESCRIPTION
It's a somewhat common issue to see the default Zenodo DOI badges (as they provide through their site) fail to render as shown below

<img width="402" height="455" alt="image" src="https://github.com/user-attachments/assets/6962be78-3171-4185-8bfe-7a790ee27a00" />

this is a simple fix that maintains the appearance and renders more reliably

(sometimes the Zenodo badge will show up if you wait long enough, or refresh page enough times, or some other magical conditions - it's just not super stable)
